### PR TITLE
Allow to set error handler on requester singleton

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: PHP
 
 on: pull_request
 

--- a/Resources/js-website/src/services/requester.js
+++ b/Resources/js-website/src/services/requester.js
@@ -1,66 +1,103 @@
 import request from '../utils/request';
 
-const defaultOptions = {
-    headers: {
-        'Content-Type': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest', // Copied from sulu/sulu
-    },
-};
-
 class Requester {
-    handleResponse(response) {
+    requestErrorHandler = null;
+    defaultOptions = {
+        headers: {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest', // Copied from sulu/sulu
+        },
+    };
+
+    interceptRequestResponse = (response) => {
         if (!response.ok) {
             return Promise.reject(response);
         }
 
-        if (response.status !== 204) {
-            return response.json();
+        if (response.status === 204) {
+            return Promise.resolve();
         }
 
-        return Promise.resolve();
-    }
+        return response.json();
+    };
+
+    interceptRequestError = (error) => {
+        if (this.requestErrorHandler) {
+            return this.requestErrorHandler(error);
+        } else {
+            throw error;
+        }
+    };
+
+    setRequestErrorHandler = (requestErrorHandler) => {
+        this.requestErrorHandler = requestErrorHandler;
+    };
+
+    setDefaultOptions = (defaultOptions) => {
+        this.defaultOptions = defaultOptions;
+    };
 
     get(url, options) {
-        return request(url, {
-            ...defaultOptions,
+        const requestOptions = {
+            ...this.defaultOptions,
             ...options,
             method: 'GET',
-        }).then(this.handleResponse);
+        };
+
+        return request(url, requestOptions)
+            .then(this.interceptRequestResponse)
+            .catch(this.interceptRequestError);
     }
 
     post(url, data, options) {
-        return request(url, {
-            ...defaultOptions,
+        const requestOptions = {
+            ...this.defaultOptions,
             ...options,
             method: 'POST',
             body: JSON.stringify(data),
-        }).then(this.handleResponse);
+        };
+
+        return request(url, requestOptions)
+            .then(this.interceptRequestResponse)
+            .catch(this.interceptRequestError);
     }
 
     put(url, data, options) {
-        return request(url, {
-            ...defaultOptions,
+        const requestOptions = {
+            ...this.defaultOptions,
             ...options,
             method: 'PUT',
             body: JSON.stringify(data),
-        }).then(this.handleResponse);
+        };
+
+        return request(url, requestOptions)
+            .then(this.interceptRequestResponse)
+            .catch(this.interceptRequestError);
     }
 
     patch(url, data, options) {
-        return request(url, {
-            ...defaultOptions,
+        const requestOptions = {
+            ...this.defaultOptions,
             ...options,
             method: 'PATCH',
             body: JSON.stringify(data),
-        }).then(this.handleResponse);
+        };
+
+        return request(url, requestOptions)
+            .then(this.interceptRequestResponse)
+            .catch(this.interceptRequestError);
     }
 
     delete(url, options) {
-        return request(url, {
-            ...defaultOptions,
+        const requestOptions = {
+            ...this.defaultOptions,
             ...options,
             method: 'DELETE',
-        }).then(this.handleResponse);
+        };
+
+        return request(url, requestOptions)
+            .then(this.interceptRequestResponse)
+            .catch(this.interceptRequestError);
     }
 }
 

--- a/Resources/js-website/src/services/requester.js
+++ b/Resources/js-website/src/services/requester.js
@@ -3,9 +3,10 @@ import request from '../utils/request';
 class Requester {
     requestErrorHandler = null;
     defaultOptions = {
+        // Copied from sulu/sulu. Will be merged with the default options of the utils/request helper.
         headers: {
             'Content-Type': 'application/json',
-            'X-Requested-With': 'XMLHttpRequest', // Copied from sulu/sulu
+            'X-Requested-With': 'XMLHttpRequest',
         },
     };
 

--- a/Resources/js-website/src/services/router.js
+++ b/Resources/js-website/src/services/router.js
@@ -44,11 +44,11 @@ class Router {
         }
 
         // If no matching static-route is registered, try to load the view data from the server
-        viewDataStore.loadData(location.pathname).then(() => {
+        return viewDataStore.loadData(location.pathname).then(() => {
             this.location = location;
         }).catch((error) => {
             if (this.viewDataErrorHandler) {
-                this.viewDataErrorHandler(error);
+                return this.viewDataErrorHandler(error);
             } else {
                 loglevel.error(
                     'Error during location change. Did not find view-data for pathname "' + location.pathname + '".',


### PR DESCRIPTION
```js
// Reload application to redirect to correct login for current environment if a request leads to a 401 response
// For example, this happens if a user clicks on a link after his cookie has expired
requester.setRequestErrorHandler((error) => {
    if (error.status === 401) {
        location.reload();

        // Return promise that will never resolve to pause promise chain
        // This prevents that any further callbacks are executed while the page is already reloading
        return new Promise(() => {});
    }

    throw error;
});
```