### PR TITLE
Fix accessing of data in twig for meta twig extension

### DIFF
--- a/Controller/HeadlessWebsiteController.php
+++ b/Controller/HeadlessWebsiteController.php
@@ -44,10 +44,9 @@ class HeadlessWebsiteController extends AbstractController
         $json = $this->serializeData($data);
 
         if ('json' !== $request->getRequestFormat()) {
-            return $this->renderTemplateResponse($structure, $requestFormat, $preview, [
-                'jsonData' => $json,
-                'data' => $data,
-            ]);
+            $data['jsonData'] = $json;
+
+            return $this->renderTemplateResponse($structure, $requestFormat, $preview, $data);
         }
 
         return new Response(

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,38 @@
 
 ## master
 
+### Data given into Twig file changed
+
+The data given to has changed to fill out the meta tags correctly:
+
+**Before:**
+
+```json
+{
+    "jsonData": "...",
+    "data": {
+        "content": {},
+        "view": {},
+        "extension": {
+            "seo": {}
+        }
+    }
+}
+```
+
+**After:**
+
+```json
+{
+    "jsonData": "...",
+    "content": {},
+    "view": {},
+    "extension": {
+        "seo": {}
+    }
+}
+```
+
 ### View Parameter of Single and Multi Selection Content Types changed
 
 The view parameter of the single and multi selection has changed to be consistent through all selections:


### PR DESCRIPTION
Currently the variables `content`, `view`, `extension` are all wrapped in the `data` object but  should be on root to correctly implement the seo.html.twig or to render data they way what twig developer would expect.

Currently he would need todo:

```twig
{% set content = data.content %}
{% set view = data.view = %}
{% set extension = data.extension %}
{# ... #}

{% extends 'base.html.twig' %}

{# ... #}
```

**BC BREAK**: This is a bc break but I think we should do this before releasing to keep the data same structure as it would be in a normal twig template in sulu.