### PR TITLE
Add interface for Serializer classes

### DIFF
--- a/Content/ContentTypeResolver/CategorySelectionResolver.php
+++ b/Content/ContentTypeResolver/CategorySelectionResolver.php
@@ -17,7 +17,7 @@ use JMS\Serializer\SerializationContext;
 use Sulu\Bundle\CategoryBundle\Api\Category;
 use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\CategorySerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\CategorySerializerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
 class CategorySelectionResolver implements ContentTypeResolverInterface
@@ -33,13 +33,13 @@ class CategorySelectionResolver implements ContentTypeResolverInterface
     private $categoryManager;
 
     /**
-     * @var CategorySerializer
+     * @var CategorySerializerInterface
      */
     private $categorySerializer;
 
     public function __construct(
         CategoryManagerInterface $categoryManager,
-        CategorySerializer $categorySerializer
+        CategorySerializerInterface $categorySerializer
     ) {
         $this->categoryManager = $categoryManager;
         $this->categorySerializer = $categorySerializer;

--- a/Content/ContentTypeResolver/ContactAccountSelectionResolver.php
+++ b/Content/ContentTypeResolver/ContactAccountSelectionResolver.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\ContactBundle\Contact\AccountManager;
 use Sulu\Bundle\ContactBundle\Contact\ContactManager;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
 class ContactAccountSelectionResolver implements ContentTypeResolverInterface
@@ -39,7 +39,7 @@ class ContactAccountSelectionResolver implements ContentTypeResolverInterface
     private $accountManager;
 
     /**
-     * @var ContactSerializer
+     * @var ContactSerializerInterface
      */
     private $contactSerializer;
 
@@ -51,7 +51,7 @@ class ContactAccountSelectionResolver implements ContentTypeResolverInterface
     public function __construct(
         ContactManager $contactManager,
         AccountManager $accountManager,
-        ContactSerializer $contactSerializer,
+        ContactSerializerInterface $contactSerializer,
         AccountSerializerInterface $accountSerializer
     ) {
         $this->contactManager = $contactManager;

--- a/Content/ContentTypeResolver/ContactAccountSelectionResolver.php
+++ b/Content/ContentTypeResolver/ContactAccountSelectionResolver.php
@@ -17,7 +17,7 @@ use JMS\Serializer\SerializationContext;
 use Sulu\Bundle\ContactBundle\Contact\AccountManager;
 use Sulu\Bundle\ContactBundle\Contact\ContactManager;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializer;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
@@ -44,7 +44,7 @@ class ContactAccountSelectionResolver implements ContentTypeResolverInterface
     private $contactSerializer;
 
     /**
-     * @var AccountSerializer
+     * @var AccountSerializerInterface
      */
     private $accountSerializer;
 
@@ -52,7 +52,7 @@ class ContactAccountSelectionResolver implements ContentTypeResolverInterface
         ContactManager $contactManager,
         AccountManager $accountManager,
         ContactSerializer $contactSerializer,
-        AccountSerializer $accountSerializer
+        AccountSerializerInterface $accountSerializer
     ) {
         $this->contactManager = $contactManager;
         $this->accountManager = $accountManager;

--- a/Content/ContentTypeResolver/MediaSelectionResolver.php
+++ b/Content/ContentTypeResolver/MediaSelectionResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver;
 
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
@@ -32,13 +32,13 @@ class MediaSelectionResolver implements ContentTypeResolverInterface
     private $mediaManager;
 
     /**
-     * @var MediaSerializer
+     * @var MediaSerializerInterface
      */
     private $mediaSerializer;
 
     public function __construct(
         MediaManagerInterface $mediaManager,
-        MediaSerializer $mediaSerializer
+        MediaSerializerInterface $mediaSerializer
     ) {
         $this->mediaManager = $mediaManager;
         $this->mediaSerializer = $mediaSerializer;

--- a/Content/ContentTypeResolver/PageSelectionResolver.php
+++ b/Content/ContentTypeResolver/PageSelectionResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver;
 
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 
@@ -26,7 +26,7 @@ class PageSelectionResolver implements ContentTypeResolverInterface
     }
 
     /**
-     * @var PageSerializer
+     * @var PageSerializerInterface
      */
     private $pageSerializer;
 
@@ -36,7 +36,7 @@ class PageSelectionResolver implements ContentTypeResolverInterface
     private $pageSelectionContainerFactory;
 
     public function __construct(
-        PageSerializer $pageSerializer,
+        PageSerializerInterface $pageSerializer,
         PageSelectionContainerFactory $pageSelectionContainerFactory
     ) {
         $this->pageSerializer = $pageSerializer;

--- a/Content/ContentTypeResolver/SingleAccountSelectionResolver.php
+++ b/Content/ContentTypeResolver/SingleAccountSelectionResolver.php
@@ -16,7 +16,7 @@ namespace Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver;
 use JMS\Serializer\SerializationContext;
 use Sulu\Bundle\ContactBundle\Contact\AccountManager;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
 class SingleAccountSelectionResolver implements ContentTypeResolverInterface
@@ -32,13 +32,13 @@ class SingleAccountSelectionResolver implements ContentTypeResolverInterface
     private $accountManager;
 
     /**
-     * @var AccountSerializer
+     * @var AccountSerializerInterface
      */
     private $accountSerializer;
 
     public function __construct(
         AccountManager $accountManager,
-        AccountSerializer $accountSerializer
+        AccountSerializerInterface $accountSerializer
     ) {
         $this->accountManager = $accountManager;
         $this->accountSerializer = $accountSerializer;

--- a/Content/ContentTypeResolver/SingleContactSelectionResolver.php
+++ b/Content/ContentTypeResolver/SingleContactSelectionResolver.php
@@ -16,7 +16,7 @@ namespace Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver;
 use JMS\Serializer\SerializationContext;
 use Sulu\Bundle\ContactBundle\Contact\ContactManager;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
 class SingleContactSelectionResolver implements ContentTypeResolverInterface
@@ -32,13 +32,13 @@ class SingleContactSelectionResolver implements ContentTypeResolverInterface
     private $contactManager;
 
     /**
-     * @var ContactSerializer
+     * @var ContactSerializerInterface
      */
     private $contactSerializer;
 
     public function __construct(
         ContactManager $contactManager,
-        ContactSerializer $contactSerializer
+        ContactSerializerInterface $contactSerializer
     ) {
         $this->contactManager = $contactManager;
         $this->contactSerializer = $contactSerializer;

--- a/Content/DataProviderResolver/MediaResolver.php
+++ b/Content/DataProviderResolver/MediaResolver.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\HeadlessBundle\Content\DataProviderResolver;
 
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Media\SmartContent\MediaDataProvider;
@@ -32,13 +32,13 @@ class MediaResolver implements DataProviderResolverInterface
     private $mediaDataProvider;
 
     /**
-     * @var MediaSerializer
+     * @var MediaSerializerInterface
      */
     private $mediaSerializer;
 
     public function __construct(
         MediaDataProvider $mediaDataProvider,
-        MediaSerializer $mediaSerializer
+        MediaSerializerInterface $mediaSerializer
     ) {
         $this->mediaDataProvider = $mediaDataProvider;
         $this->mediaSerializer = $mediaSerializer;

--- a/Content/DataProviderResolver/PageResolver.php
+++ b/Content/DataProviderResolver/PageResolver.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\HeadlessBundle\Content\DataProviderResolver;
 
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializerInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\SmartContent\PageDataProvider;
 use Sulu\Component\SmartContent\ArrayAccessItem;
@@ -32,13 +32,13 @@ class PageResolver implements DataProviderResolverInterface
     private $pageDataProvider;
 
     /**
-     * @var PageSerializer
+     * @var PageSerializerInterface
      */
     private $pageSerializer;
 
     public function __construct(
         PageDataProvider $pageDataProvider,
-        PageSerializer $pageSerializer
+        PageSerializerInterface $pageSerializer
     ) {
         $this->pageDataProvider = $pageDataProvider;
         $this->pageSerializer = $pageSerializer;

--- a/Content/Serializer/AccountSerializer.php
+++ b/Content/Serializer/AccountSerializer.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\ContactBundle\Api\Account;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 
-class AccountSerializer
+class AccountSerializer implements AccountSerializerInterface
 {
     /**
      * @var ArraySerializerInterface

--- a/Content/Serializer/AccountSerializer.php
+++ b/Content/Serializer/AccountSerializer.php
@@ -26,7 +26,7 @@ class AccountSerializer implements AccountSerializerInterface
     private $arraySerializer;
 
     /**
-     * @var MediaSerializer
+     * @var MediaSerializerInterface
      */
     private $mediaSerializer;
 
@@ -37,7 +37,7 @@ class AccountSerializer implements AccountSerializerInterface
 
     public function __construct(
         ArraySerializerInterface $arraySerializer,
-        MediaSerializer $mediaSerializer,
+        MediaSerializerInterface $mediaSerializer,
         MediaManagerInterface $mediaManager
     ) {
         $this->arraySerializer = $arraySerializer;

--- a/Content/Serializer/AccountSerializerInterface.php
+++ b/Content/Serializer/AccountSerializerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
+
+use JMS\Serializer\SerializationContext;
+use Sulu\Bundle\ContactBundle\Api\Account;
+
+interface AccountSerializerInterface
+{
+    /**
+     * @return mixed[]
+     */
+    public function serialize(Account $account, string $locale, ?SerializationContext $context = null): array;
+}

--- a/Content/Serializer/CategorySerializer.php
+++ b/Content/Serializer/CategorySerializer.php
@@ -17,7 +17,7 @@ use JMS\Serializer\SerializationContext;
 use Sulu\Bundle\CategoryBundle\Api\Category;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 
-class CategorySerializer
+class CategorySerializer implements CategorySerializerInterface
 {
     /**
      * @var ArraySerializerInterface

--- a/Content/Serializer/CategorySerializer.php
+++ b/Content/Serializer/CategorySerializer.php
@@ -25,13 +25,13 @@ class CategorySerializer implements CategorySerializerInterface
     private $arraySerializer;
 
     /**
-     * @var MediaSerializer
+     * @var MediaSerializerInterface
      */
     private $mediaSerializer;
 
     public function __construct(
         ArraySerializerInterface $arraySerializer,
-        MediaSerializer $mediaSerializer
+        MediaSerializerInterface $mediaSerializer
     ) {
         $this->arraySerializer = $arraySerializer;
         $this->mediaSerializer = $mediaSerializer;

--- a/Content/Serializer/CategorySerializerInterface.php
+++ b/Content/Serializer/CategorySerializerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
+
+use JMS\Serializer\SerializationContext;
+use Sulu\Bundle\CategoryBundle\Api\Category;
+use Sulu\Bundle\ContactBundle\Api\Account;
+
+interface CategorySerializerInterface
+{
+    /**
+     * @return mixed[]
+     */
+    public function serialize(Category $category, ?SerializationContext $context = null): array;
+}

--- a/Content/Serializer/CategorySerializerInterface.php
+++ b/Content/Serializer/CategorySerializerInterface.php
@@ -15,7 +15,6 @@ namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
 
 use JMS\Serializer\SerializationContext;
 use Sulu\Bundle\CategoryBundle\Api\Category;
-use Sulu\Bundle\ContactBundle\Api\Account;
 
 interface CategorySerializerInterface
 {

--- a/Content/Serializer/ContactSerializer.php
+++ b/Content/Serializer/ContactSerializer.php
@@ -35,7 +35,7 @@ class ContactSerializer implements ContactSerializerInterface
     private $mediaManager;
 
     /**
-     * @var MediaSerializer
+     * @var MediaSerializerInterface
      */
     private $mediaSerializer;
 
@@ -52,7 +52,7 @@ class ContactSerializer implements ContactSerializerInterface
     public function __construct(
         ArraySerializerInterface $arraySerializer,
         MediaManagerInterface $mediaManager,
-        MediaSerializer $mediaSerializer,
+        MediaSerializerInterface $mediaSerializer,
         ContactTitleRepository $contactTitleRepository,
         PositionRepository $positionRepository
     ) {

--- a/Content/Serializer/ContactSerializer.php
+++ b/Content/Serializer/ContactSerializer.php
@@ -22,7 +22,7 @@ use Sulu\Bundle\ContactBundle\Entity\PositionRepository;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 
-class ContactSerializer
+class ContactSerializer implements ContactSerializerInterface
 {
     /**
      * @var ArraySerializerInterface

--- a/Content/Serializer/ContactSerializerInterface.php
+++ b/Content/Serializer/ContactSerializerInterface.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
 
 use JMS\Serializer\SerializationContext;
-use Sulu\Bundle\CategoryBundle\Api\Category;
-use Sulu\Bundle\ContactBundle\Api\Account;
 use Sulu\Bundle\ContactBundle\Api\Contact;
 
 interface ContactSerializerInterface

--- a/Content/Serializer/ContactSerializerInterface.php
+++ b/Content/Serializer/ContactSerializerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
+
+use JMS\Serializer\SerializationContext;
+use Sulu\Bundle\CategoryBundle\Api\Category;
+use Sulu\Bundle\ContactBundle\Api\Account;
+use Sulu\Bundle\ContactBundle\Api\Contact;
+
+interface ContactSerializerInterface
+{
+    /**
+     * @return mixed[]
+     */
+    public function serialize(Contact $contact, string $locale, ?SerializationContext $context = null): array;
+}

--- a/Content/Serializer/MediaSerializer.php
+++ b/Content/Serializer/MediaSerializer.php
@@ -19,7 +19,7 @@ use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\ImageConverterInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 
-class MediaSerializer
+class MediaSerializer implements MediaSerializerInterface
 {
     /**
      * @var ArraySerializerInterface

--- a/Content/Serializer/MediaSerializerInterface.php
+++ b/Content/Serializer/MediaSerializerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
+
+use JMS\Serializer\SerializationContext;
+use Sulu\Bundle\CategoryBundle\Api\Category;
+use Sulu\Bundle\ContactBundle\Api\Account;
+use Sulu\Bundle\ContactBundle\Api\Contact;
+use Sulu\Bundle\MediaBundle\Api\Media;
+
+interface MediaSerializerInterface
+{
+    /**
+     * @return mixed[]
+     */
+    public function serialize(Media $media, ?SerializationContext $context = null): array;
+}

--- a/Content/Serializer/MediaSerializerInterface.php
+++ b/Content/Serializer/MediaSerializerInterface.php
@@ -14,9 +14,6 @@ declare(strict_types=1);
 namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
 
 use JMS\Serializer\SerializationContext;
-use Sulu\Bundle\CategoryBundle\Api\Category;
-use Sulu\Bundle\ContactBundle\Api\Account;
-use Sulu\Bundle\ContactBundle\Api\Contact;
 use Sulu\Bundle\MediaBundle\Api\Media;
 
 interface MediaSerializerInterface

--- a/Content/Serializer/PageSerializer.php
+++ b/Content/Serializer/PageSerializer.php
@@ -19,7 +19,7 @@ use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 
-class PageSerializer
+class PageSerializer implements PageSerializerInterface
 {
     /**
      * @var StructureManagerInterface

--- a/Content/Serializer/PageSerializerInterface.php
+++ b/Content/Serializer/PageSerializerInterface.php
@@ -13,9 +13,14 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
 
+use Sulu\Component\Content\Compat\PropertyParameter;
+
 interface PageSerializerInterface
 {
     /**
+     * @param mixed[] $data
+     * @param PropertyParameter[] $propertyParameters
+     *
      * @return mixed[]
      */
     public function serialize(array $data, array $propertyParameters): array;

--- a/Content/Serializer/PageSerializerInterface.php
+++ b/Content/Serializer/PageSerializerInterface.php
@@ -13,12 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
 
-use JMS\Serializer\SerializationContext;
-use Sulu\Bundle\CategoryBundle\Api\Category;
-use Sulu\Bundle\ContactBundle\Api\Account;
-use Sulu\Bundle\ContactBundle\Api\Contact;
-use Sulu\Bundle\MediaBundle\Api\Media;
-
 interface PageSerializerInterface
 {
     /**

--- a/Content/Serializer/PageSerializerInterface.php
+++ b/Content/Serializer/PageSerializerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HeadlessBundle\Content\Serializer;
+
+use JMS\Serializer\SerializationContext;
+use Sulu\Bundle\CategoryBundle\Api\Category;
+use Sulu\Bundle\ContactBundle\Api\Account;
+use Sulu\Bundle\ContactBundle\Api\Contact;
+use Sulu\Bundle\MediaBundle\Api\Media;
+
+interface PageSerializerInterface
+{
+    /**
+     * @return mixed[]
+     */
+    public function serialize(array $data, array $propertyParameters): array;
+}

--- a/Controller/NavigationController.php
+++ b/Controller/NavigationController.php
@@ -15,7 +15,7 @@ namespace Sulu\Bundle\HeadlessBundle\Controller;
 
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface;
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Sulu\Component\Rest\RequestParametersTrait;
@@ -39,14 +39,14 @@ class NavigationController
     private $serializer;
 
     /**
-     * @var MediaSerializer
+     * @var MediaSerializerInterface
      */
     private $mediaSerializer;
 
     public function __construct(
         NavigationMapperInterface $navigationMapper,
         SerializerInterface $serializer,
-        MediaSerializer $mediaSerializer
+        MediaSerializerInterface $mediaSerializer
     ) {
         $this->navigationMapper = $navigationMapper;
         $this->serializer = $serializer;

--- a/Resources/config/serializers.xml
+++ b/Resources/config/serializers.xml
@@ -10,6 +10,8 @@
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_headless.content_resolver"/>
         </service>
+        <service id="Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializerInterface" alias="sulu_headless.serializer.page"/>
+
         <service
             id="sulu_headless.serializer.account"
             class="Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializer"
@@ -18,6 +20,7 @@
             <argument type="service" id="sulu_headless.serializer.media"/>
             <argument type="service" id="sulu_media.media_manager"/>
         </service>
+        <service id="Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface" alias="sulu_headless.serializer.account"/>
 
         <service
             id="sulu_headless.serializer.contact"
@@ -29,6 +32,7 @@
             <argument type="service" id="sulu_contact.contact_title_repository"/>
             <argument type="service" id="sulu_contact.position_repository"/>
         </service>
+        <service id="Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializerInterface" alias="sulu_headless.serializer.contact"/>
 
         <service
             id="sulu_headless.serializer.media"
@@ -38,6 +42,7 @@
             <argument type="service" id="sulu_media.image.converter"/>
             <argument type="service" id="sulu_media.format_cache"/>
         </service>
+        <service id="Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface" alias="sulu_headless.serializer.media"/>
 
         <service
             id="sulu_headless.serializer.category"
@@ -46,5 +51,6 @@
             <argument type="service" id="sulu_core.array_serializer"/>
             <argument type="service" id="sulu_headless.serializer.media"/>
         </service>
+        <service id="Sulu\Bundle\HeadlessBundle\Content\Serializer\CategorySerializerInterface" alias="sulu_headless.serializer.category"/>
     </services>
 </container>

--- a/Tests/Application/.env
+++ b/Tests/Application/.env
@@ -1,2 +1,2 @@
 APP_ENV=test
-DATABASE_URL=mysql://root@localhost:3306/su_headless_test
+DATABASE_URL=mysql://root@127.0.0.1:3306/su_headless_test

--- a/Tests/Unit/Content/ContentTypeResolver/CategorySelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/CategorySelectionResolverTest.php
@@ -21,7 +21,7 @@ use Sulu\Bundle\CategoryBundle\Api\Category;
 use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\CategorySelectionResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\CategorySerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\CategorySerializerInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
@@ -33,7 +33,7 @@ class CategorySelectionResolverTest extends TestCase
     private $categoryManager;
 
     /**
-     * @var CategorySerializer|ObjectProphecy
+     * @var CategorySerializerInterface|ObjectProphecy
      */
     private $categorySerializer;
 
@@ -45,7 +45,7 @@ class CategorySelectionResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->categoryManager = $this->prophesize(CategoryManagerInterface::class);
-        $this->categorySerializer = $this->prophesize(CategorySerializer::class);
+        $this->categorySerializer = $this->prophesize(CategorySerializerInterface::class);
 
         $this->categorySelectionResolver = new CategorySelectionResolver(
             $this->categoryManager->reveal(),

--- a/Tests/Unit/Content/ContentTypeResolver/ContactAccountSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/ContactAccountSelectionResolverTest.php
@@ -24,7 +24,8 @@ use Sulu\Bundle\ContactBundle\Contact\ContactManager;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\ContactAccountSelectionResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializerInterface;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\ontactSerializer;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
 class ContactAccountSelectionResolverTest extends TestCase
@@ -40,7 +41,7 @@ class ContactAccountSelectionResolverTest extends TestCase
     private $accountManager;
 
     /**
-     * @var ContactSerializer|ObjectProphecy
+     * @var ContactSerializerInterface|ObjectProphecy
      */
     private $contactSerializer;
 
@@ -58,7 +59,7 @@ class ContactAccountSelectionResolverTest extends TestCase
     {
         $this->contactManager = $this->prophesize(ContactManager::class);
         $this->accountManager = $this->prophesize(AccountManager::class);
-        $this->contactSerializer = $this->prophesize(ContactSerializer::class);
+        $this->contactSerializer = $this->prophesize(ContactSerializerInterface::class);
         $this->accountSerializer = $this->prophesize(AccountSerializerInterface::class);
 
         $this->contactAccountResolver = new ContactAccountSelectionResolver(

--- a/Tests/Unit/Content/ContentTypeResolver/ContactAccountSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/ContactAccountSelectionResolverTest.php
@@ -25,7 +25,6 @@ use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\ContactAccountSelecti
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializerInterface;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\ontactSerializer;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
 class ContactAccountSelectionResolverTest extends TestCase

--- a/Tests/Unit/Content/ContentTypeResolver/ContactAccountSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/ContactAccountSelectionResolverTest.php
@@ -23,7 +23,7 @@ use Sulu\Bundle\ContactBundle\Contact\AccountManager;
 use Sulu\Bundle\ContactBundle\Contact\ContactManager;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\ContactAccountSelectionResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializer;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
@@ -45,7 +45,7 @@ class ContactAccountSelectionResolverTest extends TestCase
     private $contactSerializer;
 
     /**
-     * @var AccountSerializer|ObjectProphecy
+     * @var AccountSerializerInterface|ObjectProphecy
      */
     private $accountSerializer;
 
@@ -59,7 +59,7 @@ class ContactAccountSelectionResolverTest extends TestCase
         $this->contactManager = $this->prophesize(ContactManager::class);
         $this->accountManager = $this->prophesize(AccountManager::class);
         $this->contactSerializer = $this->prophesize(ContactSerializer::class);
-        $this->accountSerializer = $this->prophesize(AccountSerializer::class);
+        $this->accountSerializer = $this->prophesize(AccountSerializerInterface::class);
 
         $this->contactAccountResolver = new ContactAccountSelectionResolver(
             $this->contactManager->reveal(),

--- a/Tests/Unit/Content/ContentTypeResolver/MediaSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/MediaSelectionResolverTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\MediaSelectionResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
@@ -30,7 +30,7 @@ class MediaSelectionResolverTest extends TestCase
     private $mediaManager;
 
     /**
-     * @var MediaSerializer|ObjectProphecy
+     * @var MediaSerializerInterface|ObjectProphecy
      */
     private $mediaSerializer;
 
@@ -42,7 +42,7 @@ class MediaSelectionResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
-        $this->mediaSerializer = $this->prophesize(MediaSerializer::class);
+        $this->mediaSerializer = $this->prophesize(MediaSerializerInterface::class);
 
         $this->mediaResolver = new MediaSelectionResolver(
             $this->mediaManager->reveal(),

--- a/Tests/Unit/Content/ContentTypeResolver/PageSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/PageSelectionResolverTest.php
@@ -18,7 +18,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\PageSelectionContainerFactory;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\PageSelectionResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializerInterface;
 use Sulu\Bundle\PageBundle\Content\PageSelectionContainer;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
@@ -26,7 +26,7 @@ use Sulu\Component\Content\Compat\PropertyParameter;
 class PageSelectionResolverTest extends TestCase
 {
     /**
-     * @var PageSerializer|ObjectProphecy
+     * @var PageSerializerInterface|ObjectProphecy
      */
     private $pageSerializer;
 
@@ -42,7 +42,7 @@ class PageSelectionResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->pageSerializer = $this->prophesize(PageSerializer::class);
+        $this->pageSerializer = $this->prophesize(PageSerializerInterface::class);
         $this->pageSelectionContainerFactory = $this->prophesize(PageSelectionContainerFactory::class);
 
         $this->pageSelectionResolver = new PageSelectionResolver(

--- a/Tests/Unit/Content/ContentTypeResolver/SingleAccountSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/SingleAccountSelectionResolverTest.php
@@ -21,7 +21,7 @@ use Sulu\Bundle\ContactBundle\Api\Account;
 use Sulu\Bundle\ContactBundle\Contact\AccountManager;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\SingleAccountSelectionResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
 class SingleAccountSelectionResolverTest extends TestCase
@@ -32,7 +32,7 @@ class SingleAccountSelectionResolverTest extends TestCase
     private $accountManager;
 
     /**
-     * @var AccountSerializer|ObjectProphecy
+     * @var AccountSerializerInterface|ObjectProphecy
      */
     private $accountSerializer;
 
@@ -44,7 +44,7 @@ class SingleAccountSelectionResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->accountManager = $this->prophesize(AccountManager::class);
-        $this->accountSerializer = $this->prophesize(AccountSerializer::class);
+        $this->accountSerializer = $this->prophesize(AccountSerializerInterface::class);
 
         $this->singleAccountSelectionResolver = new SingleAccountSelectionResolver(
             $this->accountManager->reveal(),

--- a/Tests/Unit/Content/ContentTypeResolver/SingleContactSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/SingleContactSelectionResolverTest.php
@@ -21,7 +21,7 @@ use Sulu\Bundle\ContactBundle\Api\Contact;
 use Sulu\Bundle\ContactBundle\Contact\ContactManager;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\SingleContactSelectionResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
 class SingleContactSelectionResolverTest extends TestCase
@@ -32,7 +32,7 @@ class SingleContactSelectionResolverTest extends TestCase
     private $contactManager;
 
     /**
-     * @var ContactSerializer|ObjectProphecy
+     * @var ContactSerializerInterface|ObjectProphecy
      */
     private $contactSerializer;
 
@@ -44,7 +44,7 @@ class SingleContactSelectionResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->contactManager = $this->prophesize(ContactManager::class);
-        $this->contactSerializer = $this->prophesize(ContactSerializer::class);
+        $this->contactSerializer = $this->prophesize(ContactSerializerInterface::class);
 
         $this->singleContactSelectionResolver = new SingleContactSelectionResolver(
             $this->contactManager->reveal(),

--- a/Tests/Unit/Content/DataProviderResolver/MediaResolverTest.php
+++ b/Tests/Unit/Content/DataProviderResolver/MediaResolverTest.php
@@ -16,7 +16,7 @@ namespace Sulu\Bundle\HeadlessBundle\Tests\Unit\Content\DataProviderResolver;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HeadlessBundle\Content\DataProviderResolver\MediaResolver;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Media\SmartContent\MediaDataProvider;
@@ -32,7 +32,7 @@ class MediaResolverTest extends TestCase
     private $mediaDataProvider;
 
     /**
-     * @var MediaSerializer|ObjectProphecy
+     * @var MediaSerializerInterface|ObjectProphecy
      */
     private $mediaSerializer;
 
@@ -44,7 +44,7 @@ class MediaResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->mediaDataProvider = $this->prophesize(MediaDataProvider::class);
-        $this->mediaSerializer = $this->prophesize(MediaSerializer::class);
+        $this->mediaSerializer = $this->prophesize(MediaSerializerInterface::class);
 
         $this->mediaResolver = new MediaResolver(
             $this->mediaDataProvider->reveal(),

--- a/Tests/Unit/Content/DataProviderResolver/PageResolverTest.php
+++ b/Tests/Unit/Content/DataProviderResolver/PageResolverTest.php
@@ -16,7 +16,7 @@ namespace Sulu\Bundle\HeadlessBundle\Tests\Unit\Content\DataProviderResolver;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HeadlessBundle\Content\DataProviderResolver\PageResolver;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializerInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\SmartContent\PageDataProvider;
 use Sulu\Component\SmartContent\ArrayAccessItem;
@@ -31,7 +31,7 @@ class PageResolverTest extends TestCase
     private $pageDataProvider;
 
     /**
-     * @var PageSerializer|ObjectProphecy
+     * @var PageSerializerInterface|ObjectProphecy
      */
     private $pageSerializer;
 
@@ -43,7 +43,7 @@ class PageResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->pageDataProvider = $this->prophesize(PageDataProvider::class);
-        $this->pageSerializer = $this->prophesize(PageSerializer::class);
+        $this->pageSerializer = $this->prophesize(PageSerializerInterface::class);
 
         $this->pageResolver = new PageResolver(
             $this->pageDataProvider->reveal(),

--- a/Tests/Unit/Content/Serializer/AccountSerializerTest.php
+++ b/Tests/Unit/Content/Serializer/AccountSerializerTest.php
@@ -19,6 +19,7 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ContactBundle\Api\Account;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
@@ -42,7 +43,7 @@ class AccountSerializerTest extends TestCase
     private $mediaManager;
 
     /**
-     * @var AccountSerializer
+     * @var AccountSerializerInterface
      */
     private $accountSerializer;
 

--- a/Tests/Unit/Content/Serializer/AccountSerializerTest.php
+++ b/Tests/Unit/Content/Serializer/AccountSerializerTest.php
@@ -20,7 +20,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ContactBundle\Api\Account;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializer;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\AccountSerializerInterface;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
@@ -33,7 +33,7 @@ class AccountSerializerTest extends TestCase
     private $arraySerializer;
 
     /**
-     * @var MediaSerializer|ObjectProphecy
+     * @var MediaSerializerInterface|ObjectProphecy
      */
     private $mediaSerializer;
 
@@ -50,7 +50,7 @@ class AccountSerializerTest extends TestCase
     protected function setUp(): void
     {
         $this->arraySerializer = $this->prophesize(ArraySerializerInterface::class);
-        $this->mediaSerializer = $this->prophesize(MediaSerializer::class);
+        $this->mediaSerializer = $this->prophesize(MediaSerializerInterface::class);
         $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
 
         $this->accountSerializer = new AccountSerializer(

--- a/Tests/Unit/Content/Serializer/CategorySerializerTest.php
+++ b/Tests/Unit/Content/Serializer/CategorySerializerTest.php
@@ -19,7 +19,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\CategoryBundle\Api\Category;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\CategorySerializer;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\CategorySerializerInterface;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 
@@ -31,7 +31,7 @@ class CategorySerializerTest extends TestCase
     private $arraySerializer;
 
     /**
-     * @var MediaSerializer|ObjectProphecy
+     * @var MediaSerializerInterface|ObjectProphecy
      */
     private $mediaSerializer;
 
@@ -44,7 +44,7 @@ class CategorySerializerTest extends TestCase
     {
         $this->arraySerializer = $this->prophesize(ArraySerializerInterface::class);
 
-        $this->mediaSerializer = $this->prophesize(MediaSerializer::class);
+        $this->mediaSerializer = $this->prophesize(MediaSerializerInterface::class);
 
         $this->categorySerializer = new CategorySerializer(
             $this->arraySerializer->reveal(),

--- a/Tests/Unit/Content/Serializer/CategorySerializerTest.php
+++ b/Tests/Unit/Content/Serializer/CategorySerializerTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\CategoryBundle\Api\Category;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\CategorySerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\CategorySerializerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Component\Serializer\ArraySerializerInterface;
@@ -35,7 +36,7 @@ class CategorySerializerTest extends TestCase
     private $mediaSerializer;
 
     /**
-     * @var CategorySerializer
+     * @var CategorySerializerInterface
      */
     private $categorySerializer;
 

--- a/Tests/Unit/Content/Serializer/ContactSerializerTest.php
+++ b/Tests/Unit/Content/Serializer/ContactSerializerTest.php
@@ -24,7 +24,7 @@ use Sulu\Bundle\ContactBundle\Entity\Position;
 use Sulu\Bundle\ContactBundle\Entity\PositionRepository;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializer;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializerInterface;
-use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
@@ -47,7 +47,7 @@ class ContactSerializerTest extends TestCase
     private $mediaManager;
 
     /**
-     * @var MediaSerializer|ObjectProphecy
+     * @var MediaSerializerInterface|ObjectProphecy
      */
     private $mediaSerializer;
 
@@ -65,7 +65,7 @@ class ContactSerializerTest extends TestCase
     {
         $this->arraySerializer = $this->prophesize(ArraySerializerInterface::class);
         $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
-        $this->mediaSerializer = $this->prophesize(MediaSerializer::class);
+        $this->mediaSerializer = $this->prophesize(MediaSerializerInterface::class);
         $this->contactTitleRepository = $this->prophesize(ContactTitleRepository::class);
         $this->positionRepository = $this->prophesize(PositionRepository::class);
 

--- a/Tests/Unit/Content/Serializer/ContactSerializerTest.php
+++ b/Tests/Unit/Content/Serializer/ContactSerializerTest.php
@@ -23,6 +23,7 @@ use Sulu\Bundle\ContactBundle\Entity\ContactTitleRepository;
 use Sulu\Bundle\ContactBundle\Entity\Position;
 use Sulu\Bundle\ContactBundle\Entity\PositionRepository;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\ContactSerializerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
@@ -31,7 +32,7 @@ use Sulu\Component\Serializer\ArraySerializerInterface;
 class ContactSerializerTest extends TestCase
 {
     /**
-     * @var ContactSerializer
+     * @var ContactSerializerInterface
      */
     private $contactSerializer;
 

--- a/Tests/Unit/Content/Serializer/MediaSerializerTest.php
+++ b/Tests/Unit/Content/Serializer/MediaSerializerTest.php
@@ -17,6 +17,7 @@ use JMS\Serializer\SerializationContext;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\MediaSerializerInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\ImageConverterInterface;
@@ -40,7 +41,7 @@ class MediaSerializerTest extends TestCase
     private $formatCache;
 
     /**
-     * @var MediaSerializer
+     * @var MediaSerializerInterface
      */
     private $mediaSerializer;
 

--- a/Tests/Unit/Content/Serializer/PageSerializerTest.php
+++ b/Tests/Unit/Content/Serializer/PageSerializerTest.php
@@ -18,6 +18,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HeadlessBundle\Content\ContentResolverInterface;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
 use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializer;
+use Sulu\Bundle\HeadlessBundle\Content\Serializer\PageSerializerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Compat\StructureInterface;
@@ -36,7 +37,7 @@ class PageSerializerTest extends TestCase
     private $contentResolver;
 
     /**
-     * @var PageSerializer
+     * @var PageSerializerInterface
      */
     private $pageSerializer;
 


### PR DESCRIPTION
This change makes it easier to overwrite a Serializer class in a project. For example, overwriting a Serializer class is necessary if a project extends the `Media` entity.