### PR TITLE
Adjust HeadlessWebsiteController to be compatible with DefaultController

### DIFF
--- a/Controller/HeadlessWebsiteController.php
+++ b/Controller/HeadlessWebsiteController.php
@@ -16,17 +16,13 @@ namespace Sulu\Bundle\HeadlessBundle\Controller;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface;
-use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancer;
-use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancerInterface;
-use Sulu\Bundle\PreviewBundle\Preview\Preview;
+use Sulu\Bundle\WebsiteBundle\Controller\WebsiteController;
 use Sulu\Component\Content\Compat\PageInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class HeadlessWebsiteController extends AbstractController
+class HeadlessWebsiteController extends WebsiteController
 {
     /**
      * We cannot set the typehint of the $structure parameter to PageInterface because the ArticleBundle does not
@@ -40,52 +36,21 @@ class HeadlessWebsiteController extends AbstractController
         bool $preview = false,
         bool $partial = false
     ): Response {
-        /** @var string $requestFormat */
-        $requestFormat = $request->getRequestFormat();
-        $data = $this->resolveStructure($structure);
-        $json = $this->serializeData($data);
+        $headlessData = $this->resolveStructure($structure);
 
-        $response = null;
         if ('json' !== $request->getRequestFormat()) {
-            $data['jsonData'] = $json;
-            $response = $this->renderTemplateResponse($structure, $requestFormat, $preview, $data);
-        } else {
-            $response = new Response($json);
-            $response->headers->set('Content-Type', 'application/json');
+            return $this->renderStructure($structure, ['headless' => $headlessData], $preview, $partial);
         }
 
-        $cacheLifetimeEnhancer = $this->getCacheLifetimeEnhancer();
+        $response = new Response($this->serializeData($headlessData));
+        $response->headers->set('Content-Type', 'application/json');
+
+        $cacheLifetimeEnhancer = $this->getCacheTimeLifeEnhancer();
         if (!$preview && $cacheLifetimeEnhancer) {
             $cacheLifetimeEnhancer->enhance($response, $structure);
         }
 
         return $response;
-    }
-
-    /**
-     * @param PageInterface $structure
-     * @param mixed[] $parameters
-     */
-    private function renderTemplateResponse(
-        StructureInterface $structure,
-        string $requestFormat,
-        bool $preview,
-        array $parameters
-    ): Response {
-        $viewTemplate = $structure->getView() . '.' . $requestFormat . '.twig';
-
-        if (!$this->get('twig')->getLoader()->exists($viewTemplate)) {
-            throw new HttpException(406, sprintf('Page does not exist in "%s" format.', $requestFormat));
-        }
-
-        if ($preview) {
-            $parameters['previewParentTemplate'] = $viewTemplate;
-            $parameters['previewContentReplacer'] = Preview::CONTENT_REPLACER;
-
-            return $this->render('@SuluWebsite/Preview/preview.html.twig', $parameters);
-        }
-
-        return $this->render($viewTemplate, $parameters);
     }
 
     /**
@@ -119,20 +84,7 @@ class HeadlessWebsiteController extends AbstractController
         $subscribedServices = parent::getSubscribedServices();
         $subscribedServices['sulu_headless.structure_resolver'] = StructureResolverInterface::class;
         $subscribedServices['jms_serializer'] = SerializerInterface::class;
-        $subscribedServices['sulu_http_cache.cache_lifetime.enhancer'] = '?' . CacheLifetimeEnhancerInterface::class;
 
         return $subscribedServices;
-    }
-
-    protected function getCacheLifetimeEnhancer(): ?CacheLifetimeEnhancer
-    {
-        if (!$this->has('sulu_http_cache.cache_lifetime.enhancer')) {
-            return null;
-        }
-
-        /** @var CacheLifetimeEnhancer $cacheLifetimeEnhancer */
-        $cacheLifetimeEnhancer = $this->get('sulu_http_cache.cache_lifetime.enhancer');
-
-        return $cacheLifetimeEnhancer;
     }
 }

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ initialize and start the application:
     <div id="sulu-headless-container"></div>
     
     {# initialize application with json data of current page to prevent second request on first load #}
-    <script>window.SULU_HEADLESS_VIEW_DATA = {{ jsonData|raw }};</script>
+    <script>window.SULU_HEADLESS_VIEW_DATA = {{ headless|json_encode|raw }};</script>
     <script>window.SULU_HEADLESS_API_ENDPOINT = '{{ sulu_content_path('/api') }}';</script>
     
     {# start single page application by including built javascript code #}

--- a/Tests/Application/templates/headless.html.twig
+++ b/Tests/Application/templates/headless.html.twig
@@ -1,3 +1,3 @@
 {% block content %}
-    <script>window.SULU_HEADLESS_VIEW_DATA = {{ jsonData|raw }};</script>
+    <script>window.SULU_HEADLESS_VIEW_DATA = {{ headless|json_encode|raw }};</script>
 {% endblock %}

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,74 @@
 # Upgrade
 
+## dev-master
+
+### Changed attributes which are passed to templates by the HeadlessWebsiteController
+
+The attributes that are passed to the .twig template by the `HeadlessWebsiteController` were changed to improve
+compatibility with the `DefaultController` of Sulu. 
+
+If a page is requested without the `.json` suffix, the `HeadlessWebsiteController` will render the configured Twig 
+template with the data of the page. Before this change, the `HeadlessWebsiteController` passed the data generated
+by the `StructureResolver` to the template.  While this is the same data that is used for generating the `.json`
+response, it might be different to the data that is passed to the template by the `DefaultController` when not using 
+the HeadlessBundle. This behaviour makes it unnecessarily difficult to switch from the `DefaultController` to the 
+`HeadlessWebsiteController` inside of a project.
+
+After this change, the data that is passed to the template by the `HeadlessWebsiteController` will be compatible to 
+the data that would be passed by the `DefaultController`. Additionally, the data passed by the 
+`HeadlessWebsiteController` includes a `headless` attribute that contains the data generated 
+by the `StructureResolver`.
+
+In the course of this change, the `jsonData` attribute was removed from the data passed to the template. If you need
+the JSON string in your template, you can use `headless|json_encode` instead.
+
+**Before:**
+
+```php
+[
+    "type" => "page",
+    "authored" => "2020-11-25T14:31:23+0000",
+    "changed" => "2020-11-25T16:23:59+0000",
+    "created" => "2020-11-25T14:31:24+0000",
+    "content" => ["...content resolved by the StructureResolver"],
+    "view" => ["...view resolved by the StructureResolver"],
+    "extension" => ["...extension resolved by the StructureResolver"],
+    "jsonData" => "json string representation of data returned by the StructureResolver"
+];
+```
+
+```twig
+{{ jsonData|raw }}
+```
+
+**After:**
+
+```php
+[
+    "authored" => DateTime::class,
+    "changed" => DateTime::class,
+    "created" => DateTime::class,
+    "content" => ["...content resolved by the DefaultController"],
+    "view" => ["...view resolved by the DefaultController"],
+    "extension" => ["...extension resolved by the DefaultController"],
+    "headless" => [
+        "type" => "page",
+        "authored" => "2020-11-25T14:31:23+0000",
+        "changed" => "2020-11-25T16:23:59+0000",
+        "created" => "2020-11-25T14:31:24+0000",
+        "content" => ["...content resolved by the StructureResolver"],
+        "view" => ["...view resolved by the StructureResolver"],
+        "extension" => ["...extension resolved by the StructureResolver"],
+    ]   
+];
+```
+
+```twig
+{{ headless|json_encode|raw }}
+```
+
+## 0.2.0
+
 ### View Parameter of Single and Multi Selection Content Types changed
 
 The view parameter of the single and multi selection has changed to be consistent through all selections:


### PR DESCRIPTION
Ba extending the `WebsiteController` in the `HeadlessWebsiteController`, we can make it 100% compatible with the `DefaultController`. Furthermore, this way we dont need to reimplement the handling of the `$preview` and the `$partial` flag.

Fixes: https://github.com/sulu/SuluHeadlessBundle/issues/14
Replaces: https://github.com/sulu/SuluHeadlessBundle/pull/26