### PR TITLE
Handle block settings by calling block-visitors in BlockResolver

### DIFF
--- a/Resources/config/content-type-resolvers.xml
+++ b/Resources/config/content-type-resolvers.xml
@@ -128,6 +128,7 @@
             lazy="true"
         >
             <argument type="service" id="sulu_headless.content_resolver"/>
+            <argument type="tagged" tag="sulu_content.block_visitor" />
 
             <tag name="sulu_headless.content_type_resolver"/>
         </service>

--- a/Tests/Unit/Content/ContentTypeResolver/BlockResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/BlockResolverTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\HeadlessBundle\Tests\Unit\Content\ContentTypeResolver;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HeadlessBundle\Content\ContentResolverInterface;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\BlockResolver;
@@ -21,6 +22,7 @@ use Sulu\Bundle\HeadlessBundle\Content\ContentView;
 use Sulu\Component\Content\Compat\Block\BlockPropertyInterface;
 use Sulu\Component\Content\Compat\Block\BlockPropertyType;
 use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Types\Block\BlockVisitorInterface;
 
 class BlockResolverTest extends TestCase
 {
@@ -30,6 +32,16 @@ class BlockResolverTest extends TestCase
     private $contentResolver;
 
     /**
+     * @var BlockVisitorInterface|ObjectProphecy
+     */
+    private $blockVisitor1;
+
+    /**
+     * @var BlockVisitorInterface|ObjectProphecy
+     */
+    private $blockVisitor2;
+
+    /**
      * @var BlockResolver
      */
     private $blockResolver;
@@ -37,8 +49,16 @@ class BlockResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->contentResolver = $this->prophesize(ContentResolverInterface::class);
+        $this->blockVisitor1 = $this->prophesize(BlockVisitorInterface::class);
+        $this->blockVisitor2 = $this->prophesize(BlockVisitorInterface::class);
 
-        $this->blockResolver = new BlockResolver($this->contentResolver->reveal());
+        $this->blockVisitor1->visit(Argument::any())->will(function ($arguments) {return $arguments[0]; });
+        $this->blockVisitor2->visit(Argument::any())->will(function ($arguments) {return $arguments[0]; });
+
+        $this->blockResolver = new BlockResolver(
+            $this->contentResolver->reveal(),
+            new \ArrayIterator([$this->blockVisitor1->reveal(), $this->blockVisitor2->reveal()])
+        );
     }
 
     public function testGetContentType(): void
@@ -51,27 +71,40 @@ class BlockResolverTest extends TestCase
         $titleProperty = $this->prophesize(PropertyInterface::class);
         $titleProperty->getName()->willReturn('title');
         $titleProperty->getValue()->willReturn('test-123');
+
+        $titleType = $this->prophesize(BlockPropertyType::class);
+        $titleType->getName()->willReturn('title');
+        $titleType->getChildProperties()->willReturn([$titleProperty->reveal()]);
+
+        $titleContentView = $this->prophesize(ContentView::class);
+        $titleContentView->getContent()->willReturn('test-123');
+        $titleContentView->getView()->willReturn([]);
+
+        $this->contentResolver->resolve(
+            'test-123',
+            $titleProperty->reveal(),
+            'en',
+            ['webspaceKey' => 'sulu_io']
+        )->willReturn($titleContentView->reveal());
+
         $mediaProperty = $this->prophesize(PropertyInterface::class);
         $mediaProperty->getName()->willReturn('media');
         $mediaProperty->getValue()->willReturn(['ids' => [1, 2, 3]]);
 
-        $contentView1 = $this->prophesize(ContentView::class);
-        $contentView1->getContent()->willReturn('test-123');
-        $contentView1->getView()->willReturn([]);
+        $mediaType = $this->prophesize(BlockPropertyType::class);
+        $mediaType->getName()->willReturn('media');
+        $mediaType->getChildProperties()->willReturn([$mediaProperty->reveal()]);
 
-        $this->contentResolver->resolve('test-123', $titleProperty->reveal(), 'en', ['webspaceKey' => 'sulu_io'])
-            ->willReturn($contentView1->reveal());
-
-        $contentView2 = $this->prophesize(ContentView::class);
-        $contentView2->getContent()->willReturn(['media1', 'media2', 'media3']);
-        $contentView2->getView()->willReturn(['ids' => [1, 2, 3]]);
+        $mediaContentView = $this->prophesize(ContentView::class);
+        $mediaContentView->getContent()->willReturn(['media1', 'media2', 'media3']);
+        $mediaContentView->getView()->willReturn(['ids' => [1, 2, 3]]);
 
         $this->contentResolver->resolve(
             ['ids' => [1, 2, 3]],
             $mediaProperty->reveal(),
             'en',
             ['webspaceKey' => 'sulu_io']
-        )->willReturn($contentView2->reveal());
+        )->willReturn($mediaContentView->reveal());
 
         $data = [
             [
@@ -88,16 +121,13 @@ class BlockResolverTest extends TestCase
         $blockProperty->getValue()->willReturn($data);
         $blockProperty->getLength()->willReturn(2);
 
-        $titleType = $this->prophesize(BlockPropertyType::class);
-        $titleType->getName()->willReturn('title');
-        $titleType->getChildProperties()->willReturn([$titleProperty->reveal()]);
-
-        $mediaType = $this->prophesize(BlockPropertyType::class);
-        $mediaType->getName()->willReturn('media');
-        $mediaType->getChildProperties()->willReturn([$mediaProperty->reveal()]);
-
         $blockProperty->getProperties(0)->willReturn($titleType->reveal());
+        $this->blockVisitor1->visit($titleType->reveal())->willReturn($titleType->reveal());
+        $this->blockVisitor2->visit($titleType->reveal())->willReturn($titleType->reveal());
+
         $blockProperty->getProperties(1)->willReturn($mediaType->reveal());
+        $this->blockVisitor1->visit($mediaType->reveal())->willReturn($mediaType->reveal());
+        $this->blockVisitor2->visit($mediaType->reveal())->willReturn($mediaType->reveal());
 
         $result = $this->blockResolver->resolve($data, $blockProperty->reveal(), 'en', ['webspaceKey' => 'sulu_io']);
 
@@ -124,6 +154,82 @@ class BlockResolverTest extends TestCase
                     'media' => ['ids' => [1, 2, 3]],
                 ],
             ],
+            $result->getView()
+        );
+    }
+
+    public function testResolveWithSkips(): void
+    {
+        $titleProperty = $this->prophesize(PropertyInterface::class);
+        $titleProperty->getName()->willReturn('title');
+        $titleProperty->getValue()->willReturn('test-123');
+
+        $titleType = $this->prophesize(BlockPropertyType::class);
+        $titleType->getName()->willReturn('title');
+        $titleType->getChildProperties()->willReturn([$titleProperty->reveal()]);
+
+        $titleContentView = $this->prophesize(ContentView::class);
+        $titleContentView->getContent()->willReturn('test-123');
+        $titleContentView->getView()->willReturn([]);
+
+        $this->contentResolver->resolve(
+            'test-123',
+            $titleProperty->reveal(),
+            'en',
+            ['webspaceKey' => 'sulu_io']
+        )->willReturn($titleContentView->reveal());
+
+        $mediaProperty = $this->prophesize(PropertyInterface::class);
+        $mediaProperty->getName()->willReturn('media');
+        $mediaProperty->getValue()->willReturn(['ids' => [1, 2, 3]]);
+
+        $mediaType = $this->prophesize(BlockPropertyType::class);
+        $mediaType->getName()->willReturn('media');
+        $mediaType->getChildProperties()->willReturn([$mediaProperty->reveal()]);
+
+        $mediaContentView = $this->prophesize(ContentView::class);
+        $mediaContentView->getContent()->willReturn(['media1', 'media2', 'media3']);
+        $mediaContentView->getView()->willReturn(['ids' => [1, 2, 3]]);
+
+        $this->contentResolver->resolve(
+            ['ids' => [1, 2, 3]],
+            $mediaProperty->reveal(),
+            'en',
+            ['webspaceKey' => 'sulu_io']
+        )->willReturn($mediaContentView->reveal());
+
+        $data = [
+            [
+                'type' => 'title',
+                'title' => 'test-123',
+            ],
+            [
+                'type' => 'media',
+                'media' => ['ids' => [1, 2, 3]],
+            ],
+        ];
+
+        $blockProperty = $this->prophesize(BlockPropertyInterface::class);
+        $blockProperty->getValue()->willReturn($data);
+        $blockProperty->getLength()->willReturn(2);
+
+        $blockProperty->getProperties(0)->willReturn($titleType->reveal());
+        $this->blockVisitor1->visit($titleType->reveal())->willReturn(null);
+        $this->blockVisitor2->visit($titleType->reveal())->willReturn($titleType->reveal());
+
+        $blockProperty->getProperties(1)->willReturn($mediaType->reveal());
+        $this->blockVisitor1->visit($mediaType->reveal())->willReturn($mediaType->reveal());
+        $this->blockVisitor2->visit($mediaType->reveal())->willReturn(null);
+
+        $result = $this->blockResolver->resolve($data, $blockProperty->reveal(), 'en', ['webspaceKey' => 'sulu_io']);
+
+        $this->assertInstanceOf(ContentView::class, $result);
+        $this->assertSame(
+            [],
+            $result->getContent()
+        );
+        $this->assertSame(
+            [],
             $result->getView()
         );
     }


### PR DESCRIPTION
This PR adjusts the `BlockResolver` to call the registered block visitors when resolving a block. This will apply the block settings that were introduced in Sulu 2.2 and can be set by the content manager via the administration interface.

Related: https://github.com/sulu/sulu/pull/5742
Replaces: https://github.com/sulu/SuluHeadlessBundle/pull/63
