### PR TITLE
Switch key and value in propertyMap parameter of StructureResolver::resolveProperties

### DIFF
--- a/Content/ContentTypeResolver/PageSelectionResolver.php
+++ b/Content/ContentTypeResolver/PageSelectionResolver.php
@@ -89,9 +89,9 @@ class PageSelectionResolver implements ContentTypeResolverInterface
         ];
 
         foreach ($propertiesParamValue as $propertiesParamEntry) {
-            /** @var string $propertyValue */
-            $propertyValue = $propertiesParamEntry->getValue();
-            $propertyMap[$propertiesParamEntry->getName()] = $propertyValue;
+            $paramValue = $propertiesParamEntry->getValue();
+            $sourceProperty = \is_string($paramValue) ? $paramValue : $propertiesParamEntry->getName();
+            $propertyMap[$sourceProperty] = $propertiesParamEntry->getName();
         }
 
         $pages = [];

--- a/Content/DataProviderResolver/PageDataProviderResolver.php
+++ b/Content/DataProviderResolver/PageDataProviderResolver.php
@@ -124,9 +124,9 @@ class PageDataProviderResolver implements DataProviderResolverInterface
         ];
 
         foreach ($propertiesParamValue as $propertiesParamEntry) {
-            /** @var string $propertyValue */
-            $propertyValue = $propertiesParamEntry->getValue();
-            $propertyMap[$propertiesParamEntry->getName()] = $propertyValue;
+            $paramValue = $propertiesParamEntry->getValue();
+            $sourceProperty = \is_string($paramValue) ? $paramValue : $propertiesParamEntry->getName();
+            $propertyMap[$sourceProperty] = $propertiesParamEntry->getName();
         }
 
         $resolvedPages = [];

--- a/Content/StructureResolver.php
+++ b/Content/StructureResolver.php
@@ -100,9 +100,9 @@ class StructureResolver implements StructureResolverInterface
             $data['extension'] = $this->resolveExtensionData($unresolvedExtensionData, $locale, $attributes);
         }
 
-        foreach ($propertyMap as $targetProperty => $sourceProperty) {
-            if (!\is_string($targetProperty)) {
-                $targetProperty = $sourceProperty;
+        foreach ($propertyMap as $sourceProperty => $targetProperty) {
+            if (!\is_string($sourceProperty)) {
+                $sourceProperty = $targetProperty;
             }
 
             // the '.' is used to separate the extension name from the property name.

--- a/Tests/Unit/Content/ContentTypeResolver/PageSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/PageSelectionResolverTest.php
@@ -74,7 +74,7 @@ class PageSelectionResolverTest extends TestCase
         $property = $this->prophesize(PropertyInterface::class);
         $params = [
             'properties' => new PropertyParameter('properties', [
-                new PropertyParameter('title', 'title'),
+                new PropertyParameter('contentDescription', 'description'),
                 new PropertyParameter('excerptTitle', 'excerpt.title'),
                 new PropertyParameter('categories', 'excerpt.categories'),
             ]),
@@ -105,8 +105,9 @@ class PageSelectionResolverTest extends TestCase
             [
                 'title' => 'title',
                 'url' => 'url',
-                'excerptTitle' => 'excerpt.title',
-                'categories' => 'excerpt.categories',
+                'description' => 'contentDescription',
+                'excerpt.title' => 'excerptTitle',
+                'excerpt.categories' => 'categories',
             ],
             'en'
         )->willReturn([
@@ -115,12 +116,14 @@ class PageSelectionResolverTest extends TestCase
             'content' => [
                 'title' => 'Page Title 1',
                 'url' => '/page-url-1',
+                'contentDescription' => 'Page Content Description',
                 'excerptTitle' => 'Page Excerpt Title 1',
                 'categories' => [],
             ],
             'view' => [
                 'title' => [],
                 'url' => [],
+                'contentDescription' => [],
                 'excerptTitle' => [],
                 'categories' => [],
             ],
@@ -131,8 +134,9 @@ class PageSelectionResolverTest extends TestCase
             [
                 'title' => 'title',
                 'url' => 'url',
-                'excerptTitle' => 'excerpt.title',
-                'categories' => 'excerpt.categories',
+                'description' => 'contentDescription',
+                'excerpt.title' => 'excerptTitle',
+                'excerpt.categories' => 'categories',
             ],
             'en'
         )->willReturn([
@@ -141,12 +145,14 @@ class PageSelectionResolverTest extends TestCase
             'content' => [
                 'title' => 'Page Title 2',
                 'url' => '/page-url-2',
+                'contentDescription' => 'Page Content Description',
                 'excerptTitle' => 'Page Excerpt Title 2',
                 'categories' => [],
             ],
             'view' => [
                 'title' => [],
                 'url' => [],
+                'contentDescription' => [],
                 'excerptTitle' => [],
                 'categories' => [],
             ],
@@ -167,12 +173,14 @@ class PageSelectionResolverTest extends TestCase
                     'content' => [
                         'title' => 'Page Title 1',
                         'url' => '/page-url-1',
+                        'contentDescription' => 'Page Content Description',
                         'excerptTitle' => 'Page Excerpt Title 1',
                         'categories' => [],
                     ],
                     'view' => [
                         'title' => [],
                         'url' => [],
+                        'contentDescription' => [],
                         'excerptTitle' => [],
                         'categories' => [],
                     ],
@@ -183,12 +191,14 @@ class PageSelectionResolverTest extends TestCase
                     'content' => [
                         'title' => 'Page Title 2',
                         'url' => '/page-url-2',
+                        'contentDescription' => 'Page Content Description',
                         'excerptTitle' => 'Page Excerpt Title 2',
                         'categories' => [],
                     ],
                     'view' => [
                         'title' => [],
                         'url' => [],
+                        'contentDescription' => [],
                         'excerptTitle' => [],
                         'categories' => [],
                     ],

--- a/Tests/Unit/Content/DataProviderResolver/PageDataProviderResolverTest.php
+++ b/Tests/Unit/Content/DataProviderResolver/PageDataProviderResolverTest.php
@@ -104,7 +104,7 @@ class PageDataProviderResolverTest extends TestCase
 
         $propertyParameters = [
             'properties' => new PropertyParameter('properties', [
-                new PropertyParameter('contentTitle', 'title'),
+                new PropertyParameter('contentDescription', 'description'),
                 new PropertyParameter('excerptTitle', 'excerpt.title'),
             ]),
         ];
@@ -141,8 +141,8 @@ class PageDataProviderResolverTest extends TestCase
             [
                 'title' => 'title',
                 'url' => 'url',
-                'contentTitle' => 'title',
-                'excerptTitle' => 'excerpt.title',
+                'description' => 'contentDescription',
+                'excerpt.title' => 'excerptTitle',
             ],
             'en'
         )->willReturn([
@@ -151,11 +151,13 @@ class PageDataProviderResolverTest extends TestCase
             'content' => [
                 'title' => 'Page Title 1',
                 'url' => '/page-url-1',
+                'contentDescription' => 'Page Content Description',
                 'excerptTitle' => 'Page Excerpt Title 1',
             ],
             'view' => [
                 'title' => [],
                 'url' => [],
+                'contentDescription' => [],
                 'excerptTitle' => [],
             ],
         ])->shouldBeCalledOnce();
@@ -165,8 +167,8 @@ class PageDataProviderResolverTest extends TestCase
             [
                 'title' => 'title',
                 'url' => 'url',
-                'contentTitle' => 'title',
-                'excerptTitle' => 'excerpt.title',
+                'description' => 'contentDescription',
+                'excerpt.title' => 'excerptTitle',
             ],
             'en'
         )->willReturn([
@@ -175,11 +177,13 @@ class PageDataProviderResolverTest extends TestCase
             'content' => [
                 'title' => 'Page Title 2',
                 'url' => '/page-url-2',
+                'contentDescription' => 'Page Content Description',
                 'excerptTitle' => 'Page Excerpt Title 2',
             ],
             'view' => [
                 'title' => [],
                 'url' => [],
+                'contentDescription' => [],
                 'excerptTitle' => [],
             ],
         ])->shouldBeCalledOnce();
@@ -202,11 +206,13 @@ class PageDataProviderResolverTest extends TestCase
                     'content' => [
                         'title' => 'Page Title 1',
                         'url' => '/page-url-1',
+                        'contentDescription' => 'Page Content Description',
                         'excerptTitle' => 'Page Excerpt Title 1',
                     ],
                     'view' => [
                         'title' => [],
                         'url' => [],
+                        'contentDescription' => [],
                         'excerptTitle' => [],
                     ],
                 ],
@@ -216,11 +222,13 @@ class PageDataProviderResolverTest extends TestCase
                     'content' => [
                         'title' => 'Page Title 2',
                         'url' => '/page-url-2',
+                        'contentDescription' => 'Page Content Description',
                         'excerptTitle' => 'Page Excerpt Title 2',
                     ],
                     'view' => [
                         'title' => [],
                         'url' => [],
+                        'contentDescription' => [],
                         'excerptTitle' => [],
                     ],
                 ],
@@ -237,7 +245,7 @@ class PageDataProviderResolverTest extends TestCase
 
         $propertyParameters = [
             'properties' => new PropertyParameter('properties', [
-                new PropertyParameter('contentTitle', 'title'),
+                new PropertyParameter('contentDescription', 'description'),
                 new PropertyParameter('excerptTitle', 'excerpt.title'),
             ]),
         ];

--- a/Tests/Unit/Content/StructureResolverTest.php
+++ b/Tests/Unit/Content/StructureResolverTest.php
@@ -357,7 +357,7 @@ class StructureResolverTest extends TestCase
 
         $result = $this->structureResolver->resolveProperties(
             $this->structure->reveal(),
-            ['myTitle' => 'title', 'seoDescription' => 'seo.description', 'excerptTitle' => 'excerpt.title'],
+            ['title' => 'myTitle', 'seo.description' => 'seoDescription', 'excerpt.title' => 'excerptTitle'],
             'en'
         );
 
@@ -435,7 +435,7 @@ class StructureResolverTest extends TestCase
 
         $result = $this->structureResolver->resolveProperties(
             $this->structure->reveal(),
-            ['myTitle' => 'title'],
+            ['title' => 'myTitle'],
             'en',
             true
         );

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,33 @@
 
 ## 0.x
 
+### Switched meaning of key and value of propertyMap parameter of StructureResolver::resolveProperties
+
+The meaning of the key and value of the propertyMap parameter of StructureResolver::resolveProperties method was switched 
+to be consistent with similar methods in Sulu.  If you call this method in your project, you need to adjust the parameter.
+
+**Before:**
+
+```php
+$this->structureResolver->resolveProperties(
+    $structure,
+    ['title' => 'title', 'excerptTitle' => 'excerpt.title'],
+    'en'
+);
+```
+
+**After:**
+
+```php
+$this->structureResolver->resolveProperties(
+    $structure,
+    ['title' => 'title', 'excerpt.title' => 'excerptTitle'],
+    'en'
+);
+```
+
+## 0.4.0
+
 ### Increased mimimum PHP version to 7.3
 
 The mimimum PHP version was increased from 7.2 to 7.3. The reason is that PHP 7.2 is not maintained anymore and this

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Bundle that provides controllers and services for using Sulu as headless content management system",
     "require": {
         "php": "^7.3",
-        "sulu/sulu": "^2.0.1 || 2.3@dev",
+        "sulu/sulu": "^2.0.1 || ^2.3@dev",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",
         "symfony/framework-bundle": "^4.3 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Bundle that provides controllers and services for using Sulu as headless content management system",
     "require": {
         "php": "^7.3",
-        "sulu/sulu": "^2.0.1",
+        "sulu/sulu": "^2.0.1 || 2.3@dev",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",
         "symfony/framework-bundle": "^4.3 || ^5.0",
@@ -31,7 +31,6 @@
         "symfony/monolog-bundle": "^3.1",
         "thecodingmachine/phpstan-strict-rules": "^0.12"
     },
-    "minimum-stability": "dev",
     "autoload": {
         "psr-4": {
             "Sulu\\Bundle\\HeadlessBundle\\": ""


### PR DESCRIPTION
This makes the method consistent to various methods in the Sulu codebase. For example `Badge::addRouterAttributesToRequest` or `FormViewBuilderInterface::addRouterAttributesToFormRequest`.