### PR TITLE
add Extension System for StructureResolver

### DIFF
--- a/Content/StructureResolver.php
+++ b/Content/StructureResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\HeadlessBundle\Content;
 
+use Sulu\Bundle\HeadlessBundle\Content\StructureResolver\StructureResolverExtensionInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Preview\PageRouteDefaultsProvider;
@@ -50,16 +51,23 @@ class StructureResolver implements StructureResolverInterface
      */
     private $referenceStorePool;
 
+    /**
+     * @var StructureResolverExtensionInterface[]
+     */
+    private iterable $structureResolverExtensions;
+
     public function __construct(
         ContentResolverInterface $contentResolver,
         StructureManagerInterface $structureManager,
         DocumentInspector $documentInspector,
-        ReferenceStorePoolInterface $referenceStorePool
+        ReferenceStorePoolInterface $referenceStorePool,
+        iterable $structureResolverExtensions = []
     ) {
         $this->contentResolver = $contentResolver;
         $this->structureManager = $structureManager;
         $this->documentInspector = $documentInspector;
         $this->referenceStorePool = $referenceStorePool;
+        $this->structureResolverExtensions = $structureResolverExtensions;
     }
 
     /**
@@ -93,6 +101,10 @@ class StructureResolver implements StructureResolverInterface
 
             $data['content'][$property->getName()] = $contentView->getContent();
             $data['view'][$property->getName()] = $contentView->getView();
+        }
+
+        foreach ($this->structureResolverExtensions as $structureResolverExtension) {
+            $data[$structureResolverExtension->getKey()] = $structureResolverExtension->resolve($requestedStructure, $locale);
         }
 
         return $data;

--- a/Content/StructureResolver/StructureResolverExtensionInterface.php
+++ b/Content/StructureResolver/StructureResolverExtensionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HeadlessBundle\Content\StructureResolver;
+
+use Sulu\Component\Content\Compat\StructureInterface;
+
+interface StructureResolverExtensionInterface
+{
+    public function getKey(): string;
+
+    public function resolve(
+        StructureInterface $requestedStructure,
+        string $locale
+    ): mixed;
+}

--- a/README.md
+++ b/README.md
@@ -366,6 +366,31 @@ export default HeadlessTemplatePage;
 Finally, you can build your frontend application by executing `npm install` and `npm run build` in the `assets/headless`
 directory.
 
+### Extending the StructureResolver 
+To add more data to the json that is returned for a site, you can extend the StructureResolver by registering an service with the tag `sulu_headless.structure_resolver_extension`.
+
+```
+use Sulu\Bundle\HeadlessBundle\Content\StructureResolver\StructureResolverExtensionInterface;
+
+class MyStructureExtension implements StructureResolverExtensionInterface
+{
+    public function getKey(): string 
+    {
+        return 'myKey';
+    }
+    
+    public function resolve(
+        StructureInterface $requestedStructure,
+        string $locale
+    ): mixed {
+        return [
+            'foo' => 'bar',
+            'fruits' => Fruits::getArray($locale),
+            'webspaceKey' => $requestedStructure->getWebspaceKey()
+        ];
+    }
+}
+```
 
 ## ❤️&nbsp; Support and Contributions
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -22,6 +22,7 @@
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_document_manager.document_inspector"/>
             <argument type="service" id="sulu_website.reference_store_pool"/>
+            <argument type="tagged_iterator" tag="sulu_headless.structure_resolver_extension"/>
         </service>
         <service id="Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface" alias="sulu_headless.structure_resolver"/>
 


### PR DESCRIPTION
In our last projects we often have replaced the StructureResolve just because there is no extension point to extend the data there in a easy way. In non "headless" projects, the approach would be to add a TwigExtensions which makes specific data available in all twig templates. This PR makes it possible to extend structures without overriding the class, and therefore allows different bundles to extend the returned data without conflicts.