### PR TITLE
Add a StructureResolver Extension for Localization

### DIFF
--- a/Content/StructureResolver.php
+++ b/Content/StructureResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\HeadlessBundle\Content;
 
+use Sulu\Bundle\HeadlessBundle\Content\StructureResolver\StructureResolverExtensionInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Preview\PageRouteDefaultsProvider;
@@ -50,16 +51,23 @@ class StructureResolver implements StructureResolverInterface
      */
     private $referenceStorePool;
 
+    /**
+     * @var StructureResolverExtensionInterface[]
+     */
+    private iterable $structureResolverExtensions;
+
     public function __construct(
         ContentResolverInterface $contentResolver,
         StructureManagerInterface $structureManager,
         DocumentInspector $documentInspector,
-        ReferenceStorePoolInterface $referenceStorePool
+        ReferenceStorePoolInterface $referenceStorePool,
+        iterable $structureResolverExtensions = []
     ) {
         $this->contentResolver = $contentResolver;
         $this->structureManager = $structureManager;
         $this->documentInspector = $documentInspector;
         $this->referenceStorePool = $referenceStorePool;
+        $this->structureResolverExtensions = $structureResolverExtensions;
     }
 
     /**
@@ -93,6 +101,10 @@ class StructureResolver implements StructureResolverInterface
 
             $data['content'][$property->getName()] = $contentView->getContent();
             $data['view'][$property->getName()] = $contentView->getView();
+        }
+
+        foreach ($this->structureResolverExtensions as $structureResolverExtension) {
+            $data[$structureResolverExtension->getKey()] = $structureResolverExtension->resolve($requestedStructure, $locale);
         }
 
         return $data;

--- a/Content/StructureResolver/LocalizationResolverExtension.php
+++ b/Content/StructureResolver/LocalizationResolverExtension.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HeadlessBundle\Content\StructureResolver;
+
+use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+
+class LocalizationResolverExtension implements StructureResolverExtensionInterface
+{
+    private RequestAnalyzerInterface $requestAnalyzer;
+    private WebspaceManagerInterface $webspaceManager;
+
+    public function __construct(
+        RequestAnalyzerInterface $requestAnalyzer,
+        WebspaceManagerInterface $webspaceManager
+    )
+    {
+        $this->requestAnalyzer = $requestAnalyzer;
+        $this->webspaceManager = $webspaceManager;
+    }
+
+    public function getKey(): string
+    {
+        return 'localizations';
+    }
+
+    public function resolve(StructureInterface $requestedStructure, string $locale): mixed
+    {
+        $webspace = $this->requestAnalyzer->getWebspace();
+
+        if (null !== ($portal = $this->requestAnalyzer->getPortal())) {
+            $allLocalizations = $portal->getLocalizations();
+        } else {
+            $allLocalizations = $webspace->getLocalizations();
+        }
+
+        $pageUrls = [];
+        if ($requestedStructure instanceof PageBridge) {
+            $pageUrls = $requestedStructure->getUrls();
+        }
+
+        $localizations = [];
+
+        foreach ($allLocalizations as $localization) {
+            $locale = $localization->getLocale();
+
+            $alternate = true;
+            if (\array_key_exists($locale, $pageUrls)) {
+                $url = $this->webspaceManager->findUrlByResourceLocator($pageUrls[$locale], null, $locale);
+                if ($url === null) {
+                    $url = $pageUrls[$locale];
+                }
+            } else {
+                $alternate = false;
+                $url = $this->webspaceManager->findUrlByResourceLocator('/', null, $locale);
+            }
+
+            $localizations[$locale] = [
+                'locale' => $locale,
+                'url' => $url,
+                'country' => $localization->getCountry(),
+                'alternate' => $alternate,
+            ];
+        }
+        return $localizations;
+    }
+}

--- a/Content/StructureResolver/StructureResolverExtensionInterface.php
+++ b/Content/StructureResolver/StructureResolverExtensionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HeadlessBundle\Content\StructureResolver;
+
+use Sulu\Component\Content\Compat\StructureInterface;
+
+interface StructureResolverExtensionInterface
+{
+    public function getKey(): string;
+
+    public function resolve(
+        StructureInterface $requestedStructure,
+        string $locale
+    ): mixed;
+}

--- a/README.md
+++ b/README.md
@@ -366,6 +366,31 @@ export default HeadlessTemplatePage;
 Finally, you can build your frontend application by executing `npm install` and `npm run build` in the `assets/headless`
 directory.
 
+### Extending the StructureResolver 
+To add more data to the json that is returned for a site, you can extend the StructureResolver by registering an service with the tag `sulu_headless.structure_resolver_extension`.
+
+```
+use Sulu\Bundle\HeadlessBundle\Content\StructureResolver\StructureResolverExtensionInterface;
+
+class MyStructureExtension implements StructureResolverExtensionInterface
+{
+    public function getKey(): string 
+    {
+        return 'myKey';
+    }
+    
+    public function resolve(
+        StructureInterface $requestedStructure,
+        string $locale
+    ): mixed {
+        return [
+            'foo' => 'bar',
+            'fruits' => Fruits::getArray($locale),
+            'webspaceKey' => $requestedStructure->getWebspaceKey()
+        ];
+    }
+}
+```
 
 ## ❤️&nbsp; Support and Contributions
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -25,6 +25,9 @@
             <argument type="tagged_iterator" tag="sulu_headless.structure_resolver_extension"/>
         </service>
         <service id="Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface" alias="sulu_headless.structure_resolver"/>
+        <service id="Sulu\Bundle\HeadlessBundle\Content\StructureResolver\LocalizationResolverExtension" autowire="true">
+            <tag name="sulu_headless.structure_resolver_extension" />
+        </service>
 
         <service
             id="sulu_headless.content_resolver"

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -22,6 +22,7 @@
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_document_manager.document_inspector"/>
             <argument type="service" id="sulu_website.reference_store_pool"/>
+            <argument type="tagged_iterator" tag="sulu_headless.structure_resolver_extension"/>
         </service>
         <service id="Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface" alias="sulu_headless.structure_resolver"/>
 


### PR DESCRIPTION
This change adds the localizations to the json, that one can add a language-switch in the frontend without the need of many xhr-requests for performance reasons.
This is also used as an example on how to extend the StructureResolver easily as implemented in #100  