### PR TITLE
Add cache-control directive to snippet & navigation endpoints

### DIFF
--- a/Controller/NavigationController.php
+++ b/Controller/NavigationController.php
@@ -58,8 +58,8 @@ class NavigationController
         NavigationMapperInterface $navigationMapper,
         SerializerInterface $serializer,
         MediaSerializerInterface $mediaSerializer,
-                                 $maxAge,
-                                 $sharedMaxAge
+        $maxAge,
+        $sharedMaxAge
     ) {
         $this->navigationMapper = $navigationMapper;
         $this->serializer = $serializer;

--- a/Controller/NavigationController.php
+++ b/Controller/NavigationController.php
@@ -58,8 +58,8 @@ class NavigationController
         NavigationMapperInterface $navigationMapper,
         SerializerInterface $serializer,
         MediaSerializerInterface $mediaSerializer,
-        $maxAge,
-        $sharedMaxAge
+        int $maxAge,
+        int $sharedMaxAge
     ) {
         $this->navigationMapper = $navigationMapper;
         $this->serializer = $serializer;
@@ -106,7 +106,7 @@ class NavigationController
         $response->setSharedMaxAge($this->sharedMaxAge);
 
         // set reverse-proxy TTL (Symfony HttpCache, Varnish, ...) to avoid caching of intermediate proxies
-        $response->headers->set(SuluHttpCache::HEADER_REVERSE_PROXY_TTL, $this->maxAge);
+        $response->headers->set(SuluHttpCache::HEADER_REVERSE_PROXY_TTL, (string) $this->maxAge);
 
         return $response;
 

--- a/Controller/SnippetAreaController.php
+++ b/Controller/SnippetAreaController.php
@@ -66,8 +66,8 @@ class SnippetAreaController
         ContentMapperInterface $contentMapper,
         StructureResolverInterface $structureResolver,
         SerializerInterface $serializer,
-                            $maxAge,
-                            $sharedMaxAge
+        $maxAge,
+        $sharedMaxAge
     ) {
         $this->defaultSnippetManager = $defaultSnippetManager;
         $this->contentMapper = $contentMapper;

--- a/Controller/SnippetAreaController.php
+++ b/Controller/SnippetAreaController.php
@@ -66,8 +66,8 @@ class SnippetAreaController
         ContentMapperInterface $contentMapper,
         StructureResolverInterface $structureResolver,
         SerializerInterface $serializer,
-        $maxAge,
-        $sharedMaxAge
+        int $maxAge,
+        int $sharedMaxAge
     ) {
         $this->defaultSnippetManager = $defaultSnippetManager;
         $this->contentMapper = $contentMapper;
@@ -135,7 +135,7 @@ class SnippetAreaController
         $response->setSharedMaxAge($this->sharedMaxAge);
 
         // set reverse-proxy TTL (Symfony HttpCache, Varnish, ...) to avoid caching of intermediate proxies
-        $response->headers->set(SuluHttpCache::HEADER_REVERSE_PROXY_TTL, $this->maxAge);
+        $response->headers->set(SuluHttpCache::HEADER_REVERSE_PROXY_TTL, (string) $this->maxAge);
 
         return $response;
     }

--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -11,6 +11,8 @@
             <argument type="service" id="sulu_website.navigation_mapper"/>
             <argument type="service" id="jms_serializer.serializer"/>
             <argument type="service" id="sulu_headless.serializer.media"/>
+            <argument>%sulu_http_cache.cache.max_age%</argument>
+            <argument>%sulu_http_cache.cache.shared_max_age%</argument>
         </service>
         <service id="Sulu\Bundle\HeadlessBundle\Controller\NavigationController"
                  alias="sulu_headless.controller.navigation" public="true"/>
@@ -24,6 +26,8 @@
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu_headless.structure_resolver"/>
             <argument type="service" id="jms_serializer.serializer"/>
+            <argument>%sulu_http_cache.cache.max_age%</argument>
+            <argument>%sulu_http_cache.cache.shared_max_age%</argument>
         </service>
         <service id="Sulu\Bundle\HeadlessBundle\Controller\SnippetAreaController"
                  alias="sulu_headless.controller.snippet_area" public="true"/>


### PR DESCRIPTION
The HeadlessWebsiteController adds cache-control directives.
This commit add cache-control for snippet and navigation headless controllers.

It's rather simple, I initially tried to use the CacheLifetimeEnhancer but the code is much more complex (cf. attached patch).
[alternative-with-enhancer.txt](https://github.com/sulu/SuluHeadlessBundle/files/8080016/alternative-with-enhancer.txt)

