### PR TITLE
Use ContentTypeResolverInterface in constructor of SingleSelectionContentTypes 

### DIFF
--- a/Content/ContentTypeResolver/SingleMediaSelectionResolver.php
+++ b/Content/ContentTypeResolver/SingleMediaSelectionResolver.php
@@ -24,11 +24,11 @@ class SingleMediaSelectionResolver implements ContentTypeResolverInterface
     }
 
     /**
-     * @var MediaSelectionResolver
+     * @var ContentTypeResolverInterface
      */
     private $mediaSelectionResolver;
 
-    public function __construct(MediaSelectionResolver $mediaSelectionResolver)
+    public function __construct(ContentTypeResolverInterface $mediaSelectionResolver)
     {
         $this->mediaSelectionResolver = $mediaSelectionResolver;
     }

--- a/Content/ContentTypeResolver/SinglePageSelectionResolver.php
+++ b/Content/ContentTypeResolver/SinglePageSelectionResolver.php
@@ -24,11 +24,11 @@ class SinglePageSelectionResolver implements ContentTypeResolverInterface
     }
 
     /**
-     * @var PageSelectionResolver
+     * @var ContentTypeResolverInterface
      */
     private $pageSelectionResolver;
 
-    public function __construct(PageSelectionResolver $pageSelectionResolver)
+    public function __construct(ContentTypeResolverInterface $pageSelectionResolver)
     {
         $this->pageSelectionResolver = $pageSelectionResolver;
     }

--- a/Content/ContentTypeResolver/SingleSnippetSelectionResolver.php
+++ b/Content/ContentTypeResolver/SingleSnippetSelectionResolver.php
@@ -19,11 +19,11 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 class SingleSnippetSelectionResolver implements ContentTypeResolverInterface
 {
     /**
-     * @var SnippetSelectionResolver
+     * @var ContentTypeResolverInterface
      */
     private $snippetSelectionResolver;
 
-    public function __construct(SnippetSelectionResolver $snippetSelectionResolver)
+    public function __construct(ContentTypeResolverInterface $snippetSelectionResolver)
     {
         $this->snippetSelectionResolver = $snippetSelectionResolver;
     }


### PR DESCRIPTION
Using the `ContentTypeResolverInterface` allows you to decorate e.g. the `PageSelectionResolver` without having to also override the `SinglePageResolver`