### PR TITLE
Use correct locale to resolve links

### DIFF
--- a/Content/ContentTypeResolver/LinkResolver.php
+++ b/Content/ContentTypeResolver/LinkResolver.php
@@ -38,7 +38,7 @@ class LinkResolver implements ContentTypeResolverInterface
 
     public function resolve($data, PropertyInterface $property, string $locale, array $attributes = []): ContentView
     {
-        $content = $this->getContentData($property, $locale);
+        $content = $this->getContentData($property);
         $view = $this->getViewData($property);
 
         return new ContentView($content, $view);
@@ -76,9 +76,10 @@ class LinkResolver implements ContentTypeResolverInterface
         return $result;
     }
 
-    private function getContentData(PropertyInterface $property, string $locale): ?string
+    private function getContentData(PropertyInterface $property): ?string
     {
         $value = $property->getValue();
+        $locale = $property->getStructure()->getLanguageCode();
 
         if (!$value || !isset($value['provider'])) {
             return null;

--- a/Content/ContentTypeResolver/LinkResolver.php
+++ b/Content/ContentTypeResolver/LinkResolver.php
@@ -38,7 +38,7 @@ class LinkResolver implements ContentTypeResolverInterface
 
     public function resolve($data, PropertyInterface $property, string $locale, array $attributes = []): ContentView
     {
-        $content = $this->getContentData($property);
+        $content = $this->getContentData($property, $locale);
         $view = $this->getViewData($property);
 
         return new ContentView($content, $view);
@@ -76,10 +76,9 @@ class LinkResolver implements ContentTypeResolverInterface
         return $result;
     }
 
-    private function getContentData(PropertyInterface $property): ?string
+    private function getContentData(PropertyInterface $property, string $locale): ?string
     {
         $value = $property->getValue();
-        $locale = $property->getStructure()->getLanguageCode();
 
         if (!$value || !isset($value['provider'])) {
             return null;

--- a/Content/ContentTypeResolver/SnippetSelectionResolver.php
+++ b/Content/ContentTypeResolver/SnippetSelectionResolver.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver;
 
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface;
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\Structure\SnippetBridge;
@@ -75,8 +76,8 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
 
         $snippets = [];
         foreach ($snippetIds as $snippetId) {
-            /** @var SnippetBridge $snippet */
             try {
+                /** @var SnippetBridge $snippet */
                 $snippet = $this->contentMapper->load($snippetId, $webspaceKey, $locale);
             } catch (DocumentNotFoundException $e) {
                 continue;
@@ -85,15 +86,16 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
             if (!$snippet->getHasTranslation() && null !== $shadowLocale) {
                 /** @var SnippetBridge $snippet */
                 $snippet = $this->contentMapper->load($snippetId, $webspaceKey, $shadowLocale);
-                $snippet->getDocument()->setLocale($shadowLocale);
-                $snippet->getDocument()->setOriginalLocale($locale);
+                /** @var SnippetDocument $document */
+                $document = $snippet->getDocument();
+                $document->setLocale($shadowLocale);
+                $document->setOriginalLocale($locale);
             }
 
             $snippet->setIsShadow(null !== $shadowLocale);
             /** @var string $shadowBaseLanguage */
             $shadowBaseLanguage = $shadowLocale;
             $snippet->setShadowBaseLanguage($shadowBaseLanguage);
-            $snippet->setLanguageCode($locale);
 
             $snippets[] = $this->structureResolver->resolve($snippet, $locale, $includeExtension);
         }

--- a/Content/ContentTypeResolver/SnippetSelectionResolver.php
+++ b/Content/ContentTypeResolver/SnippetSelectionResolver.php
@@ -80,12 +80,15 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
             if (!$snippet->getHasTranslation() && null !== $shadowLocale) {
                 /** @var SnippetBridge $snippet */
                 $snippet = $this->contentMapper->load($snippetId, $webspaceKey, $shadowLocale);
+                $snippet->getDocument()->setLocale($shadowLocale);
+                $snippet->getDocument()->setOriginalLocale($locale);
             }
 
             $snippet->setIsShadow(null !== $shadowLocale);
             /** @var string $shadowBaseLanguage */
             $shadowBaseLanguage = $shadowLocale;
             $snippet->setShadowBaseLanguage($shadowBaseLanguage);
+            $snippet->setLanguageCode($locale);
 
             $snippets[] = $this->structureResolver->resolve($snippet, $locale, $includeExtension);
         }

--- a/Content/ContentTypeResolver/SnippetSelectionResolver.php
+++ b/Content/ContentTypeResolver/SnippetSelectionResolver.php
@@ -20,6 +20,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\Compat\Structure\StructureBridge;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 
 class SnippetSelectionResolver implements ContentTypeResolverInterface
 {
@@ -75,7 +76,11 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
         $snippets = [];
         foreach ($snippetIds as $snippetId) {
             /** @var SnippetBridge $snippet */
-            $snippet = $this->contentMapper->load($snippetId, $webspaceKey, $locale);
+            try {
+                $snippet = $this->contentMapper->load($snippetId, $webspaceKey, $locale);
+            } catch (DocumentNotFoundException $e) {
+                continue;
+            }
 
             if (!$snippet->getHasTranslation() && null !== $shadowLocale) {
                 /** @var SnippetBridge $snippet */

--- a/Tests/Unit/Content/ContentTypeResolver/SingleSnippetSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/SingleSnippetSelectionResolverTest.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\SingleSnippetSelectio
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\SnippetSelectionResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface;
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
@@ -177,6 +178,12 @@ class SingleSnippetSelectionResolverTest extends TestCase
         $snippet1de = $this->prophesize(SnippetBridge::class);
         $snippet1de->setIsShadow(true)->shouldBeCalled();
         $snippet1de->setShadowBaseLanguage('de')->shouldBeCalled();
+
+        /** @var SnippetDocument|ObjectProphecy $snippet1DeDocument */
+        $snippet1DeDocument = $this->prophesize(SnippetDocument::class);
+        $snippet1de->getDocument()->willReturn($snippet1DeDocument->reveal());
+        $snippet1DeDocument->setLocale('de')->shouldBeCalled();
+        $snippet1DeDocument->setOriginalLocale('en')->shouldBeCalled();
 
         $this->contentMapper->load('snippet-1', 'webspace-key', 'en')->willReturn($snippet1en->reveal());
         $this->contentMapper->load('snippet-1', 'webspace-key', 'de')->willReturn($snippet1de->reveal());

--- a/Tests/Unit/Content/ContentTypeResolver/SnippetSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/SnippetSelectionResolverTest.php
@@ -18,6 +18,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\SnippetSelectionResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentView;
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface;
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
@@ -233,6 +234,12 @@ class SnippetSelectionResolverTest extends TestCase
         $snippet1de = $this->prophesize(SnippetBridge::class);
         $snippet1de->setIsShadow(true)->shouldBeCalled();
         $snippet1de->setShadowBaseLanguage('de')->shouldBeCalled();
+
+        /** @var SnippetDocument|ObjectProphecy $snippet1DeDocument */
+        $snippet1DeDocument = $this->prophesize(SnippetDocument::class);
+        $snippet1de->getDocument()->willReturn($snippet1DeDocument->reveal());
+        $snippet1DeDocument->setLocale('de')->shouldBeCalled();
+        $snippet1DeDocument->setOriginalLocale('en')->shouldBeCalled();
 
         $this->contentMapper->load('snippet-1', 'webspace-key', 'en')->willReturn($snippet1en->reveal());
         $this->contentMapper->load('snippet-1', 'webspace-key', 'de')->willReturn($snippet1de->reveal());


### PR DESCRIPTION
The original locale was not set on the document, therefore the languageCode on the structure was only the shadow locale e.g. `de` instead of the original `de_ch` one