### PR TITLE
Remove kernel.reset tag from SnippetAreaInvalidationSubscriber

### DIFF
--- a/Resources/config/event-subscribers.xml
+++ b/Resources/config/event-subscribers.xml
@@ -18,7 +18,6 @@
             <argument type="service" id="sulu_http_cache.cache_manager" on-invalid="null"/>
 
             <tag name="kernel.event_subscriber" />
-            <tag name="kernel.reset" method="reset"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
The tag was wrongfully added to the subscriber, probably due to copy / pasting.

The [SnippetAreaInvalidationSubscriber](https://github.com/sulu/SuluHeadlessBundle/blob/0.x/EventSubscriber/SnippetAreaInvalidationSubscriber.php) does not even implement the `ResetInterface` and furthermore it has no variables that would make sense to reset.
Therefore this MR removes the tag on the service.