### PR TITLE
Add Attribute for sulu_headless.content_type_resolver tag

### DIFF
--- a/Attribute/AsContentTypeResolver.php
+++ b/Attribute/AsContentTypeResolver.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sulu\Bundle\HeadlessBundle\Attribute;
+
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsContentTypeResolver
+{
+
+}

--- a/SuluHeadlessBundle.php
+++ b/SuluHeadlessBundle.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\HeadlessBundle;
 
+use Sulu\Bundle\HeadlessBundle\Attribute\AsContentTypeResolver;
 use Sulu\Bundle\HeadlessBundle\Content\ContentTypeResolver\ContentTypeResolverInterface;
 use Sulu\Bundle\HeadlessBundle\Content\DataProviderResolver\DataProviderResolverInterface;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -30,5 +32,9 @@ class SuluHeadlessBundle extends Bundle
 
         $container->registerForAutoconfiguration(DataProviderResolverInterface::class)
             ->addTag('sulu_headless.data_provider_resolver');
+
+        $container->registerAttributeForAutoconfiguration(AsContentTypeResolver::class, static function (ChildDefinition $definition, AsContentTypeResolver $attribute) {
+            $definition->addTag('sulu_headless.content_type_resolver', get_object_vars($attribute));
+        });
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| License | MIT

#### What's in this PR?

It should be possible to set the required tag, which is needed to load the ContentTypeResolver, via annotation in the future.

#### Example

```php
#[AsContentTypeResolver]
class ExampleContenType implements ContentTypeResolverInterface
{

    public static function getContentType(): string
    {
        return 'test_type';
    }

    public function resolve($data, PropertyInterface $property, string $locale, array $attributes = []): ContentView
    {
        return new ContentView(['test' => 'foo']);
    }
}
```

#### Why?

In Symfony, the configuration process using attributes has become very common. Why Sulu as a Symfony CMS should adapt here
