### PR TITLE
Add support for CacheLifetime for scheduled blocks in SnippetAreaController

### DIFF
--- a/Content/DataProviderResolver/PageDataProviderResolver.php
+++ b/Content/DataProviderResolver/PageDataProviderResolver.php
@@ -102,7 +102,7 @@ class PageDataProviderResolver implements DataProviderResolverInterface
 
         $pageIds = [];
         foreach ($providerResult->getItems() as $resultItem) {
-            $pageIds[] = $resultItem->getId();
+            $pageIds[] = (string) $resultItem->getId();
         }
 
         /** @var PropertyParameter[] $propertiesParamValue */

--- a/Content/DataProviderResolver/SnippetDataProviderResolver.php
+++ b/Content/DataProviderResolver/SnippetDataProviderResolver.php
@@ -95,7 +95,7 @@ class SnippetDataProviderResolver implements DataProviderResolverInterface
 
         $snippetIds = [];
         foreach ($providerResult->getItems() as $resultItem) {
-            $snippetIds[] = $resultItem->getId();
+            $snippetIds[] = (string) $resultItem->getId();
         }
 
         /** @var PropertyParameter[] $propertiesParamValue */

--- a/Controller/SnippetAreaController.php
+++ b/Controller/SnippetAreaController.php
@@ -168,7 +168,7 @@ class SnippetAreaController
         $response->setSharedMaxAge($this->sharedMaxAge);
 
         $cacheLifetime = $this->cacheLifetime;
-        if ($this->cacheLifetimeRequestStore !== null) {
+        if (null !== $this->cacheLifetimeRequestStore) {
             $this->cacheLifetimeRequestStore->setCacheLifetime($this->cacheLifetime);
             $cacheLifetime = $this->cacheLifetimeRequestStore->getCacheLifetime();
         }

--- a/Controller/SnippetAreaController.php
+++ b/Controller/SnippetAreaController.php
@@ -17,6 +17,7 @@ use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface;
 use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
+use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeRequestStore;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
@@ -72,6 +73,11 @@ class SnippetAreaController
      */
     private $cacheLifetime;
 
+    /**
+     * @var CacheLifetimeRequestStore|null
+     */
+    private $cacheLifetimeRequestStore;
+
     public function __construct(
         DefaultSnippetManagerInterface $defaultSnippetManager,
         ContentMapperInterface $contentMapper,
@@ -80,7 +86,8 @@ class SnippetAreaController
         ?ReferenceStoreInterface $snippetReferenceStore,
         int $maxAge,
         int $sharedMaxAge,
-        int $cacheLifetime
+        int $cacheLifetime,
+        ?CacheLifetimeRequestStore $cacheLifetimeRequestStore = null
     ) {
         $this->defaultSnippetManager = $defaultSnippetManager;
         $this->contentMapper = $contentMapper;
@@ -90,6 +97,14 @@ class SnippetAreaController
         $this->maxAge = $maxAge;
         $this->sharedMaxAge = $sharedMaxAge;
         $this->cacheLifetime = $cacheLifetime;
+        $this->cacheLifetimeRequestStore = $cacheLifetimeRequestStore;
+
+        if (null === $cacheLifetimeRequestStore) {
+            @\trigger_error(
+                'Instantiating the SnippetAreaController without the $cacheLifetimeRequestStore argument is deprecated!',
+                \E_USER_DEPRECATED
+            );
+        }
     }
 
     public function getAction(Request $request, string $area): Response
@@ -151,7 +166,17 @@ class SnippetAreaController
         $response->setPublic();
         $response->setMaxAge($this->maxAge);
         $response->setSharedMaxAge($this->sharedMaxAge);
-        $response->headers->set(SuluHttpCache::HEADER_REVERSE_PROXY_TTL, (string) $this->cacheLifetime);
+
+        $cacheLifetime = $this->cacheLifetime;
+        if ($this->cacheLifetimeRequestStore !== null) {
+            $this->cacheLifetimeRequestStore->setCacheLifetime($this->cacheLifetime);
+            $cacheLifetime = $this->cacheLifetimeRequestStore->getCacheLifetime();
+        }
+
+        $response->headers->set(
+            SuluHttpCache::HEADER_REVERSE_PROXY_TTL,
+            (string) $cacheLifetime
+        );
 
         return $response;
     }

--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -32,6 +32,7 @@
             <argument>%sulu_http_cache.cache.max_age%</argument>
             <argument>%sulu_http_cache.cache.shared_max_age%</argument>
             <argument>%sulu_headless.snippet_area.cache_lifetime%</argument>
+            <argument type="service" id="sulu_http_cache.cache_lifetime.request_store" on-invalid="null"/>
         </service>
         <service id="Sulu\Bundle\HeadlessBundle\Controller\SnippetAreaController"
                  alias="sulu_headless.controller.snippet_area" public="true"/>

--- a/Tests/Application/config/templates/snippets/default-blocks.xml
+++ b/Tests/Application/config/templates/snippets/default-blocks.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default-blocks</key>
+
+    <meta>
+        <title>Default Blocks</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title>Title</title>
+            </meta>
+
+            <tag name="sulu.node.name"/>
+        </property>
+
+        <property name="description" type="text_editor">
+            <meta>
+                <title>Description</title>
+            </meta>
+        </property>
+
+        <block name="blocks">
+            <types>
+                <type name="editor_image">
+                    <meta>
+                        <title lang="de">Editor</title>
+                        <title lang="en">Editor</title>
+                    </meta>
+
+                    <properties>
+                        <property name="article" type="text_editor">
+                            <meta>
+                                <title lang="de">Artikel</title>
+                                <title lang="en">Article</title>
+                            </meta>
+                        </property>
+                    </properties>
+                </type>
+            </types>
+        </block>
+    </properties>
+</template>


### PR DESCRIPTION
Adds the support for dynamic `X-Reverse-Proxy-TTL` header for the SnippetAreaController. The ttl is dynamically calculated for e.g. scheduled blocks.