### PR TITLE
Bugfix for non-int page value

### DIFF
--- a/Content/ContentTypeResolver/SmartContentResolver.php
+++ b/Content/ContentTypeResolver/SmartContentResolver.php
@@ -220,7 +220,7 @@ class SmartContentResolver implements ContentTypeResolverInterface
             return 1;
         }
 
-        $page = $this->requestStack->getCurrentRequest()->get($pageParameter, 1);
+        $page = (int) $this->requestStack->getCurrentRequest()->get($pageParameter, 1);
 
         if ($page <= 1) {
             $page = 1;
@@ -230,7 +230,7 @@ class SmartContentResolver implements ContentTypeResolverInterface
             return \PHP_INT_MAX;
         }
 
-        return (int) $page;
+        return $page;
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/7881
| License | MIT

#### What's in this PR?

Cast the smart_content page parameter to int before comparing.

#### Why?

Because otherwise the value is too big for Elasticsearch and an error is thrown...

```
{"error":{"root_cause":[{"type":"input_coercion_exception","reason":"Numeric value (1.1068046444225731e+20) out of range of int (-2147483648 - 2147483647)\n at [Source: (org.elasticsearch.common.io.stream.ByteBufferStreamInput); line: 1, column: 354]"}],"type":"input_coercion_exception","reason":"Numeric value (1.1068046444225731e+20) out of range of int (-2147483648 - 2147483647)\n at [Source: (org.elasticsearch.common.io.stream.ByteBufferStreamInput); line: 1, column: 354]"},"status":500}
```
