### PR TITLE
Sulu 3.0 fixes (return null for empty excerpt single selects, fix smart content operators, fix nippet selection order, only resolve live data)

### DIFF
--- a/Content/ContentTypeResolver/ArticleSelectionResolver.php
+++ b/Content/ContentTypeResolver/ArticleSelectionResolver.php
@@ -31,7 +31,6 @@ class ArticleSelectionResolver implements ContentTypeResolverInterface
         private StructureResolverInterface $structureResolver,
         private ArticleRepositoryInterface $articleRepository,
         private ContentAggregatorInterface $contentAggregator,
-        private bool $showDrafts,
     ) {
     }
 
@@ -43,12 +42,11 @@ class ArticleSelectionResolver implements ContentTypeResolverInterface
 
         $propertyMap = $this->getPropertyMap($fieldMetadata);
 
-        $stage = $this->showDrafts ? DimensionContentInterface::STAGE_DRAFT : DimensionContentInterface::STAGE_LIVE;
         $articles = $this->articleRepository->findBy(
             [
                 'uuids' => $data,
                 'locale' => $locale,
-                'stage' => $stage,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
             ],
             [],
             [ArticleRepositoryInterface::GROUP_SELECT_ARTICLE_WEBSITE => true],
@@ -58,7 +56,7 @@ class ArticleSelectionResolver implements ContentTypeResolverInterface
         foreach ($articles as $article) {
             $dimensionContent = $this->contentAggregator->aggregate(
                 $article,
-                ['locale' => $locale, 'stage' => $stage],
+                ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_LIVE],
             );
 
             $resolvedArticles[$article->getUuid()] = $this->structureResolver->resolveProperties(

--- a/Content/ContentTypeResolver/PageSelectionResolver.php
+++ b/Content/ContentTypeResolver/PageSelectionResolver.php
@@ -31,7 +31,6 @@ class PageSelectionResolver implements ContentTypeResolverInterface
         private StructureResolverInterface $structureResolver,
         private PageRepositoryInterface $pageRepository,
         private ContentAggregatorInterface $contentAggregator,
-        private bool $showDrafts,
     ) {
     }
 
@@ -43,12 +42,11 @@ class PageSelectionResolver implements ContentTypeResolverInterface
 
         $propertyMap = $this->getPropertyMap($fieldMetadata);
 
-        $stage = $this->showDrafts ? DimensionContentInterface::STAGE_DRAFT : DimensionContentInterface::STAGE_LIVE;
         $pages = $this->pageRepository->findBy(
             [
                 'uuids' => $data,
                 'locale' => $locale,
-                'stage' => $stage,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
             ],
             [],
             [PageRepositoryInterface::GROUP_SELECT_PAGE_WEBSITE => true],
@@ -58,7 +56,7 @@ class PageSelectionResolver implements ContentTypeResolverInterface
         foreach ($pages as $page) {
             $dimensionContent = $this->contentAggregator->aggregate(
                 $page,
-                ['locale' => $locale, 'stage' => $stage],
+                ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_LIVE],
             );
 
             $resolvedPages[$page->getUuid()] = $this->structureResolver->resolveProperties(

--- a/Content/ContentTypeResolver/SnippetSelectionResolver.php
+++ b/Content/ContentTypeResolver/SnippetSelectionResolver.php
@@ -33,7 +33,6 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
         private StructureResolverInterface $structureResolver,
         private ContentAggregatorInterface $contentAggregator,
         private SnippetAreaRepositoryInterface $snippetAreaRepository,
-        private readonly bool $showDrafts = false,
     ) {
     }
 
@@ -72,13 +71,12 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
             return new ContentView([], ['ids' => []]);
         }
 
-        $stage = $this->showDrafts ? DimensionContentInterface::STAGE_DRAFT : DimensionContentInterface::STAGE_LIVE;
         $loadLocale = $shadowLocale ?? $locale;
         $snippetEntities = $this->snippetRepository->findBy(
             [
                 'uuids' => $snippetIds,
                 'locale' => $loadLocale,
-                'stage' => $stage,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
                 'load_ghost_content' => true,
             ],
             [],
@@ -89,7 +87,7 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
         foreach ($snippetEntities as $snippet) {
             $dimensionContent = $this->contentAggregator->aggregate(
                 $snippet,
-                ['locale' => $loadLocale, 'stage' => $stage],
+                ['locale' => $loadLocale, 'stage' => DimensionContentInterface::STAGE_LIVE],
             );
             $snippets[$snippet->getUuid()] = $this->structureResolver->resolve($dimensionContent, $locale, $includeExtension);
         }

--- a/Content/ContentTypeResolver/SnippetSelectionResolver.php
+++ b/Content/ContentTypeResolver/SnippetSelectionResolver.php
@@ -33,6 +33,7 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
         private StructureResolverInterface $structureResolver,
         private ContentAggregatorInterface $contentAggregator,
         private SnippetAreaRepositoryInterface $snippetAreaRepository,
+        private readonly bool $showDrafts = false,
     ) {
     }
 
@@ -71,12 +72,13 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
             return new ContentView([], ['ids' => []]);
         }
 
+        $stage = $this->showDrafts ? DimensionContentInterface::STAGE_DRAFT : DimensionContentInterface::STAGE_LIVE;
         $loadLocale = $shadowLocale ?? $locale;
         $snippetEntities = $this->snippetRepository->findBy(
             [
                 'uuids' => $snippetIds,
                 'locale' => $loadLocale,
-                'stage' => DimensionContentInterface::STAGE_LIVE,
+                'stage' => $stage,
                 'load_ghost_content' => true,
             ],
             [],
@@ -87,7 +89,7 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
         foreach ($snippetEntities as $snippet) {
             $dimensionContent = $this->contentAggregator->aggregate(
                 $snippet,
-                ['locale' => $loadLocale, 'stage' => DimensionContentInterface::STAGE_LIVE],
+                ['locale' => $loadLocale, 'stage' => $stage],
             );
             $snippets[$snippet->getUuid()] = $this->structureResolver->resolve($dimensionContent, $locale, $includeExtension);
         }

--- a/Content/ContentTypeResolver/SnippetSelectionResolver.php
+++ b/Content/ContentTypeResolver/SnippetSelectionResolver.php
@@ -83,15 +83,15 @@ class SnippetSelectionResolver implements ContentTypeResolverInterface
             [SnippetRepositoryInterface::GROUP_SELECT_SNIPPET_WEBSITE => true],
         );
 
-        $snippets = [];
+        $snippets = \array_fill_keys($snippetIds, null);
         foreach ($snippetEntities as $snippet) {
             $dimensionContent = $this->contentAggregator->aggregate(
                 $snippet,
                 ['locale' => $loadLocale, 'stage' => DimensionContentInterface::STAGE_LIVE],
             );
-            $snippets[] = $this->structureResolver->resolve($dimensionContent, $locale, $includeExtension);
+            $snippets[$snippet->getUuid()] = $this->structureResolver->resolve($dimensionContent, $locale, $includeExtension);
         }
 
-        return new ContentView($snippets, ['ids' => $snippetIds]);
+        return new ContentView(\array_values(\array_filter($snippets)), ['ids' => $snippetIds]);
     }
 }

--- a/Content/DataProviderResolver/ArticleDataProviderResolver.php
+++ b/Content/DataProviderResolver/ArticleDataProviderResolver.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
 
 class ArticleDataProviderResolver implements DataProviderResolverInterface
 {
@@ -32,7 +33,6 @@ class ArticleDataProviderResolver implements DataProviderResolverInterface
         private StructureResolverInterface $structureResolver,
         private ArticleRepositoryInterface $articleRepository,
         private ContentAggregatorInterface $contentAggregator,
-        private bool $showDrafts,
     ) {
     }
 
@@ -73,13 +73,11 @@ class ArticleDataProviderResolver implements DataProviderResolverInterface
             return new DataProviderResult([], false);
         }
 
-        $stage = $this->showDrafts ? 'draft' : 'live';
-
         $articles = $this->articleRepository->findBy(
             [
                 'uuids' => $ids,
                 'locale' => $locale,
-                'stage' => $stage,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
             ],
             [],
             [ArticleRepositoryInterface::GROUP_SELECT_ARTICLE_WEBSITE => true],
@@ -104,7 +102,7 @@ class ArticleDataProviderResolver implements DataProviderResolverInterface
         foreach ($articles as $articleEntity) {
             $dimensionContent = $this->contentAggregator->aggregate(
                 $articleEntity,
-                ['locale' => $locale, 'stage' => $stage],
+                ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_LIVE],
             );
             $resolvedArticles[$articleEntity->getUuid()] = $this->structureResolver->resolveProperties(
                 $dimensionContent,

--- a/Content/DataProviderResolver/ArticlePageTreeDataProviderResolver.php
+++ b/Content/DataProviderResolver/ArticlePageTreeDataProviderResolver.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
 
 class ArticlePageTreeDataProviderResolver implements DataProviderResolverInterface
 {
@@ -32,7 +33,6 @@ class ArticlePageTreeDataProviderResolver implements DataProviderResolverInterfa
         private StructureResolverInterface $structureResolver,
         private ArticleRepositoryInterface $articleRepository,
         private ContentAggregatorInterface $contentAggregator,
-        private bool $showDrafts,
     ) {
     }
 
@@ -73,13 +73,11 @@ class ArticlePageTreeDataProviderResolver implements DataProviderResolverInterfa
             return new DataProviderResult([], false);
         }
 
-        $stage = $this->showDrafts ? 'draft' : 'live';
-
         $articles = $this->articleRepository->findBy(
             [
                 'uuids' => $ids,
                 'locale' => $locale,
-                'stage' => $stage,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
             ],
             [],
             [ArticleRepositoryInterface::GROUP_SELECT_ARTICLE_WEBSITE => true],
@@ -104,7 +102,7 @@ class ArticlePageTreeDataProviderResolver implements DataProviderResolverInterfa
         foreach ($articles as $articleEntity) {
             $dimensionContent = $this->contentAggregator->aggregate(
                 $articleEntity,
-                ['locale' => $locale, 'stage' => $stage],
+                ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_LIVE],
             );
             $resolvedArticles[$articleEntity->getUuid()] = $this->structureResolver->resolveProperties(
                 $dimensionContent,

--- a/Content/DataProviderResolver/PageDataProviderResolver.php
+++ b/Content/DataProviderResolver/PageDataProviderResolver.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 
 class PageDataProviderResolver implements DataProviderResolverInterface
@@ -32,7 +33,6 @@ class PageDataProviderResolver implements DataProviderResolverInterface
         private StructureResolverInterface $structureResolver,
         private PageRepositoryInterface $pageRepository,
         private ContentAggregatorInterface $contentAggregator,
-        private bool $showDrafts,
     ) {
     }
 
@@ -74,13 +74,11 @@ class PageDataProviderResolver implements DataProviderResolverInterface
             return new DataProviderResult([], false);
         }
 
-        $stage = $this->showDrafts ? 'draft' : 'live';
-
         $pages = $this->pageRepository->findBy(
             [
                 'uuids' => $ids,
                 'locale' => $locale,
-                'stage' => $stage,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
             ],
             [],
             [PageRepositoryInterface::GROUP_SELECT_PAGE_WEBSITE => true],
@@ -105,7 +103,7 @@ class PageDataProviderResolver implements DataProviderResolverInterface
         foreach ($pages as $pageEntity) {
             $dimensionContent = $this->contentAggregator->aggregate(
                 $pageEntity,
-                ['locale' => $locale, 'stage' => $stage],
+                ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_LIVE],
             );
             $resolvedPages[$pageEntity->getUuid()] = $this->structureResolver->resolveProperties(
                 $dimensionContent,

--- a/Content/DataProviderResolver/PageDataProviderResolver.php
+++ b/Content/DataProviderResolver/PageDataProviderResolver.php
@@ -133,13 +133,13 @@ class PageDataProviderResolver implements DataProviderResolverInterface
 
         return [
             'categories' => $filters['categories'] ?? [],
-            'categoryOperator' => $filters['categoryOperator'] ?? 'OR',
+            'categoryOperator' => \strtoupper(\is_string($filters['categoryOperator'] ?? null) ? $filters['categoryOperator'] : 'OR'),
             'websiteCategories' => $filters['websiteCategories'] ?? [],
-            'websiteCategoryOperator' => $filters['websiteCategoriesOperator'] ?? 'OR',
+            'websiteCategoryOperator' => \strtoupper(\is_string($filters['websiteCategoriesOperator'] ?? null) ? $filters['websiteCategoriesOperator'] : 'OR'),
             'tags' => $filters['tags'] ?? [],
-            'tagOperator' => $filters['tagOperator'] ?? 'OR',
+            'tagOperator' => \strtoupper(\is_string($filters['tagOperator'] ?? null) ? $filters['tagOperator'] : 'OR'),
             'websiteTags' => $filters['websiteTags'] ?? [],
-            'websiteTagOperator' => $filters['websiteTagsOperator'] ?? 'OR',
+            'websiteTagOperator' => \strtoupper(\is_string($filters['websiteTagsOperator'] ?? null) ? $filters['websiteTagsOperator'] : 'OR'),
             'types' => $filters['types'] ?? [],
             'typesOperator' => 'OR',
             'locale' => $locale,

--- a/Content/ExtensionResolver/ExcerptResolver.php
+++ b/Content/ExtensionResolver/ExcerptResolver.php
@@ -168,8 +168,20 @@ class ExcerptResolver implements ExtensionResolverInterface
 
     private function getEmptyValue(string $fieldType): mixed
     {
-        $arrayTypes = [
+        $nullTypes = [
+            'single_account_selection',
+            'single_article_selection',
+            'single_category_selection',
+            'single_collection_selection',
+            'single_contact_selection',
+            'single_icon_selection',
             'single_media_selection',
+            'single_page_selection',
+            'single_select',
+            'single_snippet_selection',
+        ];
+
+        $arrayTypes = [
             'media_selection',
             'category_selection',
             'tag_selection',
@@ -177,6 +189,10 @@ class ExcerptResolver implements ExtensionResolverInterface
             'page_selection',
             'segment_select',
         ];
+
+        if (\in_array($fieldType, $nullTypes, true)) {
+            return null;
+        }
 
         if (\in_array($fieldType, $arrayTypes, true)) {
             return [];

--- a/Resources/config/article-resolvers.xml
+++ b/Resources/config/article-resolvers.xml
@@ -12,7 +12,6 @@
             <argument type="service" id="sulu_headless.structure_resolver"/>
             <argument type="service" id="Sulu\Article\Domain\Repository\ArticleRepositoryInterface"/>
             <argument type="service" id="Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface"/>
-            <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
 
             <tag name="sulu_headless.content_type_resolver"/>
         </service>
@@ -36,7 +35,6 @@
             <argument type="service" id="sulu_headless.structure_resolver"/>
             <argument type="service" id="Sulu\Article\Domain\Repository\ArticleRepositoryInterface"/>
             <argument type="service" id="Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface"/>
-            <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
 
             <tag name="sulu_headless.data_provider_resolver"/>
         </service>
@@ -49,7 +47,6 @@
             <argument type="service" id="sulu_headless.structure_resolver"/>
             <argument type="service" id="Sulu\Article\Domain\Repository\ArticleRepositoryInterface"/>
             <argument type="service" id="Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface"/>
-            <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
 
             <tag name="sulu_headless.data_provider_resolver"/>
         </service>

--- a/Resources/config/content-type-resolvers.xml
+++ b/Resources/config/content-type-resolvers.xml
@@ -21,7 +21,6 @@
             <argument type="service" id="sulu_headless.structure_resolver"/>
             <argument type="service" id="Sulu\Page\Domain\Repository\PageRepositoryInterface"/>
             <argument type="service" id="Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface"/>
-            <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
 
             <tag name="sulu_headless.content_type_resolver"/>
         </service>
@@ -35,7 +34,6 @@
             <argument type="service" id="sulu_headless.structure_resolver"/>
             <argument type="service" id="Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface"/>
             <argument type="service" id="sulu_snippet.snippet_area_repository"/>
-            <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
 
             <tag name="sulu_headless.content_type_resolver"/>
         </service>

--- a/Resources/config/content-type-resolvers.xml
+++ b/Resources/config/content-type-resolvers.xml
@@ -35,6 +35,7 @@
             <argument type="service" id="sulu_headless.structure_resolver"/>
             <argument type="service" id="Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface"/>
             <argument type="service" id="sulu_snippet.snippet_area_repository"/>
+            <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
 
             <tag name="sulu_headless.content_type_resolver"/>
         </service>

--- a/Resources/config/data-provider-resolvers.xml
+++ b/Resources/config/data-provider-resolvers.xml
@@ -44,7 +44,6 @@
             <argument type="service" id="sulu_headless.structure_resolver"/>
             <argument type="service" id="Sulu\Page\Domain\Repository\PageRepositoryInterface"/>
             <argument type="service" id="Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface"/>
-            <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
 
             <tag name="sulu_headless.data_provider_resolver"/>
         </service>

--- a/Tests/Functional/Controller/Integration/responses/smart-content/pages__with_excerpt.json
+++ b/Tests/Functional/Controller/Integration/responses/smart-content/pages__with_excerpt.json
@@ -19,7 +19,7 @@
                     "excerptTitle": "Excerpt Title One",
                     "excerptDescription": "First page excerpt description",
                     "excerptTags": [],
-                    "excerptImage": []
+                    "excerptImage": null
                 },
                 "view": {
                     "title": [],
@@ -49,7 +49,7 @@
                     "excerptTitle": "Excerpt Title Two",
                     "excerptDescription": "Second page excerpt description",
                     "excerptTags": [],
-                    "excerptImage": []
+                    "excerptImage": null
                 },
                 "view": {
                     "title": [],

--- a/Tests/Unit/Content/ContentTypeResolver/ArticleSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/ArticleSelectionResolverTest.php
@@ -60,7 +60,6 @@ class ArticleSelectionResolverTest extends TestCase
             $this->structureResolver->reveal(),
             $this->articleRepository->reveal(),
             $this->contentAggregator->reveal(),
-            false,
         );
     }
 
@@ -188,54 +187,6 @@ class ArticleSelectionResolverTest extends TestCase
         $this->assertInstanceOf(ContentView::class, $result);
         $this->assertSame([], $result->getContent());
         $this->assertSame(['ids' => []], $result->getView());
-    }
-
-    public function testResolveWithShowDrafts(): void
-    {
-        $locale = 'en';
-
-        $articleSelectionResolver = new ArticleSelectionResolver(
-            $this->structureResolver->reveal(),
-            $this->articleRepository->reveal(),
-            $this->contentAggregator->reveal(),
-            true,
-        );
-
-        $article1 = new Article('article-id-1');
-        $dimensionContent1 = new ArticleDimensionContent($article1);
-
-        $this->articleRepository->findBy(
-            [
-                'uuids' => ['article-id-1'],
-                'locale' => $locale,
-                'stage' => DimensionContentInterface::STAGE_DRAFT,
-            ],
-            [],
-            [ArticleRepositoryInterface::GROUP_SELECT_ARTICLE_WEBSITE => true],
-        )->willReturn([$article1]);
-
-        $this->contentAggregator->aggregate(
-            $article1,
-            ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_DRAFT],
-        )->willReturn($dimensionContent1);
-
-        $this->structureResolver->resolveProperties(
-            $dimensionContent1,
-            ['title' => 'title', 'url' => 'url'],
-            $locale,
-        )->willReturn([
-            'id' => 'article-id-1',
-            'template' => 'default',
-            'content' => ['title' => 'Article Title 1', 'url' => '/article-url-1'],
-            'view' => ['title' => [], 'url' => []],
-        ]);
-
-        $result = $articleSelectionResolver->resolve(['article-id-1'], $this->fieldMetadata, $locale, []);
-
-        $this->assertInstanceOf(ContentView::class, $result);
-        $content = $result->getContent();
-        $this->assertIsArray($content);
-        $this->assertCount(1, $content);
     }
 
     public function testResolveWithCustomProperties(): void

--- a/Tests/Unit/Content/ContentTypeResolver/PageSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/PageSelectionResolverTest.php
@@ -60,7 +60,6 @@ class PageSelectionResolverTest extends TestCase
             $this->structureResolver->reveal(),
             $this->pageRepository->reveal(),
             $this->contentAggregator->reveal(),
-            false, // showDrafts
         );
     }
 
@@ -188,54 +187,6 @@ class PageSelectionResolverTest extends TestCase
         $this->assertInstanceOf(ContentView::class, $result);
         $this->assertSame([], $result->getContent());
         $this->assertSame(['ids' => []], $result->getView());
-    }
-
-    public function testResolveWithShowDrafts(): void
-    {
-        $locale = 'en';
-
-        $pageSelectionResolver = new PageSelectionResolver(
-            $this->structureResolver->reveal(),
-            $this->pageRepository->reveal(),
-            $this->contentAggregator->reveal(),
-            true,
-        );
-
-        $page1 = new Page('page-id-1');
-        $dimensionContent1 = new PageDimensionContent($page1);
-
-        $this->pageRepository->findBy(
-            [
-                'uuids' => ['page-id-1'],
-                'locale' => $locale,
-                'stage' => DimensionContentInterface::STAGE_DRAFT,
-            ],
-            [],
-            [PageRepositoryInterface::GROUP_SELECT_PAGE_WEBSITE => true],
-        )->willReturn([$page1]);
-
-        $this->contentAggregator->aggregate(
-            $page1,
-            ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_DRAFT],
-        )->willReturn($dimensionContent1);
-
-        $this->structureResolver->resolveProperties(
-            $dimensionContent1,
-            ['title' => 'title', 'url' => 'url'],
-            $locale,
-        )->willReturn([
-            'id' => 'page-id-1',
-            'template' => 'default',
-            'content' => ['title' => 'Page Title 1', 'url' => '/page-url-1'],
-            'view' => ['title' => [], 'url' => []],
-        ]);
-
-        $result = $pageSelectionResolver->resolve(['page-id-1'], $this->fieldMetadata, $locale, []);
-
-        $this->assertInstanceOf(ContentView::class, $result);
-        $content = $result->getContent();
-        $this->assertIsArray($content);
-        $this->assertCount(1, $content);
     }
 
     public function testResolveWithCustomProperties(): void

--- a/Tests/Unit/Content/ContentTypeResolver/SnippetSelectionResolverTest.php
+++ b/Tests/Unit/Content/ContentTypeResolver/SnippetSelectionResolverTest.php
@@ -82,7 +82,10 @@ class SnippetSelectionResolverTest extends TestCase
         $locale = 'en';
 
         $snippet1 = $this->prophesize(SnippetInterface::class);
+        $snippet1->getUuid()->willReturn('snippet-1');
+
         $snippet2 = $this->prophesize(SnippetInterface::class);
+        $snippet2->getUuid()->willReturn('snippet-2');
 
         $dimensionContent1 = $this->prophesize(SnippetDimensionContentInterface::class);
         $dimensionContent2 = $this->prophesize(SnippetDimensionContentInterface::class);

--- a/Tests/Unit/Content/DataProviderResolver/ArticleDataProviderResolverTest.php
+++ b/Tests/Unit/Content/DataProviderResolver/ArticleDataProviderResolverTest.php
@@ -65,7 +65,6 @@ class ArticleDataProviderResolverTest extends TestCase
             $this->structureResolver->reveal(),
             $this->articleRepository->reveal(),
             $this->contentAggregator->reveal(),
-            true,
         );
     }
 
@@ -121,13 +120,13 @@ class ArticleDataProviderResolverTest extends TestCase
         $mergedContent2 = $this->prophesize(DimensionContentInterface::class);
 
         $this->contentAggregator->aggregate(
-            $article1,
-            ['locale' => 'en', 'stage' => 'draft']
+            $article1->reveal(),
+            ['locale' => 'en', 'stage' => DimensionContentInterface::STAGE_LIVE]
         )->willReturn($mergedContent1->reveal());
 
         $this->contentAggregator->aggregate(
-            $article2,
-            ['locale' => 'en', 'stage' => 'draft']
+            $article2->reveal(),
+            ['locale' => 'en', 'stage' => DimensionContentInterface::STAGE_LIVE]
         )->willReturn($mergedContent2->reveal());
 
         $this->structureResolver->resolveProperties(

--- a/Tests/Unit/Content/DataProviderResolver/ArticlePageTreeDataProviderResolverTest.php
+++ b/Tests/Unit/Content/DataProviderResolver/ArticlePageTreeDataProviderResolverTest.php
@@ -65,7 +65,6 @@ class ArticlePageTreeDataProviderResolverTest extends TestCase
             $this->structureResolver->reveal(),
             $this->articleRepository->reveal(),
             $this->contentAggregator->reveal(),
-            true,
         );
     }
 
@@ -121,13 +120,13 @@ class ArticlePageTreeDataProviderResolverTest extends TestCase
         $mergedContent2 = $this->prophesize(DimensionContentInterface::class);
 
         $this->contentAggregator->aggregate(
-            $article1,
-            ['locale' => 'en', 'stage' => 'draft']
+            $article1->reveal(),
+            ['locale' => 'en', 'stage' => DimensionContentInterface::STAGE_LIVE]
         )->willReturn($mergedContent1->reveal());
 
         $this->contentAggregator->aggregate(
-            $article2,
-            ['locale' => 'en', 'stage' => 'draft']
+            $article2->reveal(),
+            ['locale' => 'en', 'stage' => DimensionContentInterface::STAGE_LIVE]
         )->willReturn($mergedContent2->reveal());
 
         $this->structureResolver->resolveProperties(

--- a/Tests/Unit/Content/DataProviderResolver/PageDataProviderResolverTest.php
+++ b/Tests/Unit/Content/DataProviderResolver/PageDataProviderResolverTest.php
@@ -65,7 +65,6 @@ class PageDataProviderResolverTest extends TestCase
             $this->structureResolver->reveal(),
             $this->pageRepository->reveal(),
             $this->contentAggregator->reveal(),
-            true, // showDrafts
         );
     }
 
@@ -124,13 +123,13 @@ class PageDataProviderResolverTest extends TestCase
         $mergedContent2 = $this->prophesize(DimensionContentInterface::class);
 
         $this->contentAggregator->aggregate(
-            $page1,
-            ['locale' => 'en', 'stage' => 'draft']
+            $page1->reveal(),
+            ['locale' => 'en', 'stage' => DimensionContentInterface::STAGE_LIVE]
         )->willReturn($mergedContent1->reveal());
 
         $this->contentAggregator->aggregate(
-            $page2,
-            ['locale' => 'en', 'stage' => 'draft']
+            $page2->reveal(),
+            ['locale' => 'en', 'stage' => DimensionContentInterface::STAGE_LIVE]
         )->willReturn($mergedContent2->reveal());
 
         $this->structureResolver->resolveProperties(

--- a/Tests/Unit/Content/ExtensionResolver/ExcerptResolverTest.php
+++ b/Tests/Unit/Content/ExtensionResolver/ExcerptResolverTest.php
@@ -168,7 +168,7 @@ class ExcerptResolverTest extends TestCase
         $this->assertSame(['myTags' => ['tag1', 'tag2']], $result->getContent());
     }
 
-    public function testResolveWithNullContent(): void
+    public function testResolveWithNullContentMedia(): void
     {
         $dimensionContent = $this->createExcerptDimensionContent();
         $dimensionContent->getExcerptData()->willReturn([]);
@@ -192,6 +192,32 @@ class ExcerptResolverTest extends TestCase
         );
 
         $this->assertSame(['myMedia' => []], $result->getContent());
+    }
+
+    public function testResolveWithNullContentSingleMedia(): void
+    {
+        $dimensionContent = $this->createExcerptDimensionContent();
+        $dimensionContent->getExcerptData()->willReturn([]);
+
+        $mediaField = new FieldMetadata('excerpt/media');
+        $mediaField->setType('single_media_selection');
+
+        $formMetadata = $this->prophesize(FormMetadata::class);
+        $formMetadata->getFlatFieldMetadata()->willReturn(['excerpt/media' => $mediaField]);
+
+        $this->formMetadataProvider->getMetadata('content_excerpt', 'en', Argument::type('array'))
+            ->willReturn($formMetadata->reveal());
+
+        $this->contentResolver->resolve(null, $mediaField, 'en', Argument::type('array'))
+            ->willReturn(new ContentView(null, []));
+
+        $result = $this->excerptResolver->resolve(
+            $dimensionContent->reveal(),
+            ['myMedia' => 'excerpt.media'],
+            'en'
+        );
+
+        $this->assertSame(['myMedia' => null], $result->getContent());
     }
 
     public function testResolveWithNullContentTextType(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -107,7 +107,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$dimensionContent of method Sulu\\\\Bundle\\\\HeadlessBundle\\\\Content\\\\ExtensionResolver\\\\ExcerptResolver\\:\\:resolve\\(\\) expects Sulu\\\\Content\\\\Domain\\\\Model\\\\DimensionContentInterface, object given\\.$#"
-			count: 7
+			count: 8
 			path: Tests/Unit/Content/ExtensionResolver/ExcerptResolverTest.php
 
 		-


### PR DESCRIPTION
- Return null for excerpt single selects when they are empty, so existing code does not break
- Fix smart content operators by making them uppercase
- Change Snippet selection order like it was in Sulu 2.6
- Only resolve live data (In Sulu 3.0 only live data is shown in preview)