### PR TITLE
Fix url resolution and test compatibility after Sulu 3.0.6 upgrade

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -26,7 +26,7 @@ $config->setRiskyAllowed(true)
             'multi_line_extends_each_single_line' => true,
         ] ,
         'linebreak_after_opening_tag' => true,
-//        'declare_strict_types' => true,
+        'declare_strict_types' => true,
         'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
         'native_constant_invocation' => true,
         'native_function_casing' => true,

--- a/Content/StructureResolver.php
+++ b/Content/StructureResolver.php
@@ -15,12 +15,12 @@ namespace Sulu\Bundle\HeadlessBundle\Content;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Bundle\HeadlessBundle\Content\ExtensionResolver\ExtensionResolverProvider;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
+use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
 use Sulu\Content\Domain\Model\AuthorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\ExcerptInterface;

--- a/Content/StructureResolver.php
+++ b/Content/StructureResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\HeadlessBundle\Content;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
@@ -23,6 +24,7 @@ use Sulu\Content\Domain\Model\AuthorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\ExcerptInterface;
 use Sulu\Content\Domain\Model\LinkInterface;
+use Sulu\Content\Domain\Model\RoutableInterface;
 use Sulu\Content\Domain\Model\SeoInterface;
 use Sulu\Content\Domain\Model\ShadowInterface;
 use Sulu\Content\Domain\Model\TaxonomyInterface;
@@ -149,6 +151,7 @@ class StructureResolver implements StructureResolverInterface
 
         $fieldMetadataList = $formMetadata->getFlatFieldMetadata();
         $templateData = $dimensionContent->getTemplateData();
+        $templateData = $this->fillRouteFieldsFromRoute($dimensionContent, $templateData, $fieldMetadataList);
 
         if (null !== $properties) {
             $filteredFieldMetadata = [];
@@ -214,6 +217,56 @@ class StructureResolver implements StructureResolverInterface
                 $view = \array_merge($view, $extensionView->getView());
             }
         }
+    }
+
+    /**
+     * Fills route and page_tree_route field values from the Route entity into templateData.
+     * Since Sulu 3.0.6 these fields are not persisted in templateData anymore.
+     *
+     * @param array<string, mixed> $templateData
+     * @param array<string, FieldMetadata> $fieldMetadataList
+     *
+     * @return array<string, mixed>
+     */
+    private function fillRouteFieldsFromRoute(
+        TemplateInterface $dimensionContent,
+        array $templateData,
+        array $fieldMetadataList,
+    ): array {
+        if (!$dimensionContent instanceof RoutableInterface) {
+            return $templateData;
+        }
+
+        $route = $dimensionContent->getRoute();
+        if (null === $route) {
+            return $templateData;
+        }
+
+        foreach ($fieldMetadataList as $name => $field) {
+            $type = $field->getType();
+            if ('route' === $type) {
+                $templateData[$name] = $route->getSlug();
+            } elseif ('page_tree_route' === $type) {
+                $parentRoute = $route->getParentRoute();
+                if (null === $parentRoute) {
+                    continue;
+                }
+                $parentSlug = $parentRoute->getSlug();
+                $slug = $route->getSlug();
+                $suffix = \str_starts_with($slug, $parentSlug)
+                    ? \substr($slug, \strlen($parentSlug))
+                    : '';
+                $templateData[$name] = [
+                    'page' => [
+                        'uuid' => $parentRoute->getResourceId(),
+                        'path' => $parentSlug,
+                    ],
+                    'suffix' => $suffix,
+                ];
+            }
+        }
+
+        return $templateData;
     }
 
     /**

--- a/Content/StructureResolver.php
+++ b/Content/StructureResolver.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\HeadlessBundle\Content;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Bundle\HeadlessBundle\Content\ExtensionResolver\ExtensionResolverProvider;
@@ -220,9 +221,6 @@ class StructureResolver implements StructureResolverInterface
     }
 
     /**
-     * Fills route and page_tree_route field values from the Route entity into templateData.
-     * Since Sulu 3.0.6 these fields are not persisted in templateData anymore.
-     *
      * @param array<string, mixed> $templateData
      * @param array<string, FieldMetadata> $fieldMetadataList
      *
@@ -243,6 +241,10 @@ class StructureResolver implements StructureResolverInterface
         }
 
         foreach ($fieldMetadataList as $name => $field) {
+            if (!$field->hasTag(TemplateDataMapper::SKIP_TAG)) {
+                continue;
+            }
+
             $type = $field->getType();
             if ('route' === $type) {
                 $templateData[$name] = $route->getSlug();

--- a/Tests/Functional/Controller/responses/navigation__get.json
+++ b/Tests/Functional/Controller/responses/navigation__get.json
@@ -24,7 +24,58 @@
                 "creator": null,
                 "created": "@string@.isDateTime()",
                 "order": "@integer@",
-                "children": []
+                "children": [
+                    {
+                        "id": "@uuid@",
+                        "uuid": "@uuid@",
+                        "linkType": null,
+                        "publishedState": true,
+                        "published": "@string@.isDateTime()",
+                        "title": "Test 1A",
+                        "locale": "de",
+                        "webspaceKey": "sulu_io",
+                        "template": "default",
+                        "parent": "@null@||@uuid@",
+                        "url": "/test-1a",
+                        "urls": {
+                            "de": "/test-1a"
+                        },
+                        "lastModified": null,
+                        "author": null,
+                        "authored": "@string@.isDateTime()",
+                        "changer": null,
+                        "changed": "@string@.isDateTime()",
+                        "creator": null,
+                        "created": "@string@.isDateTime()",
+                        "order": "@integer@",
+                        "children": []
+                    },
+                    {
+                        "id": "@uuid@",
+                        "uuid": "@uuid@",
+                        "linkType": null,
+                        "publishedState": true,
+                        "published": "@string@.isDateTime()",
+                        "title": "Test 1B",
+                        "locale": "de",
+                        "webspaceKey": "sulu_io",
+                        "template": "default",
+                        "parent": "@null@||@uuid@",
+                        "url": "/test-1b",
+                        "urls": {
+                            "de": "/test-1b"
+                        },
+                        "lastModified": null,
+                        "author": null,
+                        "authored": "@string@.isDateTime()",
+                        "changer": null,
+                        "changed": "@string@.isDateTime()",
+                        "creator": null,
+                        "created": "@string@.isDateTime()",
+                        "order": "@integer@",
+                        "children": []
+                    }
+                ]
             },
             {
                 "id": "@uuid@",

--- a/Tests/Functional/Controller/responses/navigation__get_excerpt.json
+++ b/Tests/Functional/Controller/responses/navigation__get_excerpt.json
@@ -33,7 +33,76 @@
                     "icon": null,
                     "image": null
                 },
-                "children": []
+                "children": [
+                    {
+                        "id": "@uuid@",
+                        "uuid": "@uuid@",
+                        "linkType": null,
+                        "publishedState": true,
+                        "published": "@string@.isDateTime()",
+                        "title": "Test 1A",
+                        "locale": "de",
+                        "webspaceKey": "sulu_io",
+                        "template": "default",
+                        "parent": "@null@||@uuid@",
+                        "url": "/test-1a",
+                        "urls": {
+                            "de": "/test-1a"
+                        },
+                        "lastModified": null,
+                        "author": null,
+                        "authored": "@string@.isDateTime()",
+                        "changer": null,
+                        "changed": "@string@.isDateTime()",
+                        "creator": null,
+                        "created": "@string@.isDateTime()",
+                        "order": "@integer@",
+                        "excerpt": {
+                            "title": "",
+                            "more": "",
+                            "description": "",
+                            "categories": [],
+                            "tags": [],
+                            "icon": null,
+                            "image": null
+                        },
+                        "children": []
+                    },
+                    {
+                        "id": "@uuid@",
+                        "uuid": "@uuid@",
+                        "linkType": null,
+                        "publishedState": true,
+                        "published": "@string@.isDateTime()",
+                        "title": "Test 1B",
+                        "locale": "de",
+                        "webspaceKey": "sulu_io",
+                        "template": "default",
+                        "parent": "@null@||@uuid@",
+                        "url": "/test-1b",
+                        "urls": {
+                            "de": "/test-1b"
+                        },
+                        "lastModified": null,
+                        "author": null,
+                        "authored": "@string@.isDateTime()",
+                        "changer": null,
+                        "changed": "@string@.isDateTime()",
+                        "creator": null,
+                        "created": "@string@.isDateTime()",
+                        "order": "@integer@",
+                        "excerpt": {
+                            "title": "",
+                            "more": "",
+                            "description": "",
+                            "categories": [],
+                            "tags": [],
+                            "icon": null,
+                            "image": null
+                        },
+                        "children": []
+                    }
+                ]
             },
             {
                 "id": "@uuid@",

--- a/Tests/Traits/CreateSnippetTrait.php
+++ b/Tests/Traits/CreateSnippetTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/Tests/Traits/CreateSnippetTrait.php
+++ b/Tests/Traits/CreateSnippetTrait.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -64,7 +62,7 @@ trait CreateSnippetTrait
                 $tagManager = static::getContainer()->get(TagManagerInterface::class);
                 $tagIds = [];
                 foreach ($excerptData['tags'] as $tagName) {
-                    $tag = $tagManager->findOrCreateByName($tagName);
+                    $tag = $tagManager->findByName($tagName) ?? $tagManager->save(['name' => $tagName]);
                     $tagIds[] = $tag->getId();
                 }
                 $snippetData['excerptTags'] = $tagIds;

--- a/Tests/Traits/CreateSnippetTrait.php
+++ b/Tests/Traits/CreateSnippetTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\HeadlessBundle\Tests\Traits;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Content\Domain\Model\WorkflowInterface;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
 use Sulu\Snippet\Application\Message\ApplyWorkflowTransitionSnippetMessage;
@@ -60,7 +61,13 @@ trait CreateSnippetTrait
         if (isset($data['excerpt']) && \is_array($data['excerpt'])) {
             $excerptData = $data['excerpt'];
             if (isset($excerptData['tags']) && \is_array($excerptData['tags'])) {
-                $snippetData['excerptTags'] = $excerptData['tags'];
+                $tagManager = static::getContainer()->get(TagManagerInterface::class);
+                $tagIds = [];
+                foreach ($excerptData['tags'] as $tagName) {
+                    $tag = $tagManager->findOrCreateByName($tagName);
+                    $tagIds[] = $tag->getId();
+                }
+                $snippetData['excerptTags'] = $tagIds;
             }
             if (isset($excerptData['categories']) && \is_array($excerptData['categories'])) {
                 $snippetData['excerptCategories'] = $excerptData['categories'];

--- a/Tests/Unit/Content/StructureResolverTest.php
+++ b/Tests/Unit/Content/StructureResolverTest.php
@@ -584,39 +584,4 @@ class StructureResolverTest extends TestCase
         $this->assertSame('', $result['content']['url']['suffix']);
     }
 
-    public function testResolveSkipsRouteFieldWithoutSkipTag(): void
-    {
-        $route = new Route('pages', 'page-uuid', 'en', '/my-slug');
-
-        $page = new Page('123-123-123');
-        $page->setWebspaceKey('sulu_io');
-        $page->setCreated(new \DateTimeImmutable('2024-01-01 10:00:00'));
-        $page->setChanged(new \DateTimeImmutable('2024-01-02 15:00:00'));
-
-        $dimensionContent = new PageDimensionContent($page);
-        $dimensionContent->setTemplateKey('default');
-        $dimensionContent->setTemplateData(['url' => '/existing-value']);
-        $dimensionContent->setRoute($route);
-
-        $urlField = new FieldMetadata('url');
-        $urlField->setType('route');
-
-        $formMetadata = $this->prophesize(FormMetadata::class);
-        $formMetadata->getFlatFieldMetadata()->willReturn(['url' => $urlField]);
-
-        $typedFormMetadata = $this->prophesize(TypedFormMetadata::class);
-        $typedFormMetadata->getForms()->willReturn(['default' => $formMetadata->reveal()]);
-
-        $this->formMetadataProvider->getMetadata('page', 'en', [])->willReturn($typedFormMetadata->reveal());
-
-        $this->contentResolver->resolve('/existing-value', $urlField, 'en', Argument::type('array'))
-            ->willReturn(new ContentView('/existing-value', []));
-
-        $this->referenceStore->add('123-123-123', 'pages')->shouldBeCalled();
-
-        /** @var array{content: array<string, mixed>} $result */
-        $result = $this->structureResolver->resolve($dimensionContent, 'en', false);
-
-        $this->assertSame('/existing-value', $result['content']['url']);
-    }
 }

--- a/Tests/Unit/Content/StructureResolverTest.php
+++ b/Tests/Unit/Content/StructureResolverTest.php
@@ -19,6 +19,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Bundle\HeadlessBundle\Content\ContentResolverInterface;
@@ -28,8 +29,10 @@ use Sulu\Bundle\HeadlessBundle\Content\ExtensionResolver\ExtensionResolverProvid
 use Sulu\Bundle\HeadlessBundle\Content\ExtensionResolver\SeoResolver;
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolver;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
+use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContent;
+use Sulu\Route\Domain\Model\Route;
 
 class StructureResolverTest extends TestCase
 {
@@ -407,5 +410,213 @@ class StructureResolverTest extends TestCase
 
         $this->assertNull($result['author']);
         $this->assertSame('2024-01-15T12:00:00+00:00', $result['authored']);
+    }
+
+    public function testResolveRouteFieldFromRoute(): void
+    {
+        $route = new Route('pages', 'page-uuid', 'en', '/my-slug');
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu_io');
+        $page->setCreated(new \DateTimeImmutable('2024-01-01 10:00:00'));
+        $page->setChanged(new \DateTimeImmutable('2024-01-02 15:00:00'));
+
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setTemplateKey('default');
+        $dimensionContent->setTemplateData([]);
+        $dimensionContent->setRoute($route);
+
+        $tag = new TagMetadata();
+        $tag->setName(TemplateDataMapper::SKIP_TAG);
+
+        $urlField = new FieldMetadata('url');
+        $urlField->setType('route');
+        $urlField->addTag($tag);
+
+        $formMetadata = $this->prophesize(FormMetadata::class);
+        $formMetadata->getFlatFieldMetadata()->willReturn(['url' => $urlField]);
+
+        $typedFormMetadata = $this->prophesize(TypedFormMetadata::class);
+        $typedFormMetadata->getForms()->willReturn(['default' => $formMetadata->reveal()]);
+
+        $this->formMetadataProvider->getMetadata('page', 'en', [])->willReturn($typedFormMetadata->reveal());
+
+        $this->contentResolver->resolve('/my-slug', $urlField, 'en', Argument::type('array'))
+            ->willReturn(new ContentView('/my-slug', []));
+
+        $this->referenceStore->add('123-123-123', 'pages')->shouldBeCalled();
+
+        /** @var array{content: array<string, mixed>} $result */
+        $result = $this->structureResolver->resolve($dimensionContent, 'en', false);
+
+        $this->assertSame('/my-slug', $result['content']['url']);
+    }
+
+    public function testResolvePageTreeRouteFieldFromRoute(): void
+    {
+        $parentRoute = new Route('pages', 'parent-uuid', 'en', '/parent');
+        $route = new Route('pages', 'page-uuid', 'en', '/parent/child', null, $parentRoute);
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu_io');
+        $page->setCreated(new \DateTimeImmutable('2024-01-01 10:00:00'));
+        $page->setChanged(new \DateTimeImmutable('2024-01-02 15:00:00'));
+
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setTemplateKey('default');
+        $dimensionContent->setTemplateData([]);
+        $dimensionContent->setRoute($route);
+
+        $tag = new TagMetadata();
+        $tag->setName(TemplateDataMapper::SKIP_TAG);
+
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('page_tree_route');
+        $routeField->addTag($tag);
+
+        $formMetadata = $this->prophesize(FormMetadata::class);
+        $formMetadata->getFlatFieldMetadata()->willReturn(['url' => $routeField]);
+
+        $typedFormMetadata = $this->prophesize(TypedFormMetadata::class);
+        $typedFormMetadata->getForms()->willReturn(['default' => $formMetadata->reveal()]);
+
+        $this->formMetadataProvider->getMetadata('page', 'en', [])->willReturn($typedFormMetadata->reveal());
+
+        $expectedValue = [
+            'page' => ['uuid' => 'parent-uuid', 'path' => '/parent'],
+            'suffix' => '/child',
+        ];
+        $this->contentResolver->resolve($expectedValue, $routeField, 'en', Argument::type('array'))
+            ->willReturn(new ContentView($expectedValue, []));
+
+        $this->referenceStore->add('123-123-123', 'pages')->shouldBeCalled();
+
+        /** @var array{content: array<string, array{page: array{path: string, uuid: string}, suffix: string}>} $result */
+        $result = $this->structureResolver->resolve($dimensionContent, 'en', false);
+
+        $this->assertSame('/parent', $result['content']['url']['page']['path']);
+        $this->assertSame('parent-uuid', $result['content']['url']['page']['uuid']);
+        $this->assertSame('/child', $result['content']['url']['suffix']);
+    }
+
+    public function testResolvePageTreeRouteFieldNoParentRoute(): void
+    {
+        $route = new Route('pages', 'page-uuid', 'en', '/my-slug');
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu_io');
+        $page->setCreated(new \DateTimeImmutable('2024-01-01 10:00:00'));
+        $page->setChanged(new \DateTimeImmutable('2024-01-02 15:00:00'));
+
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setTemplateKey('default');
+        $dimensionContent->setTemplateData([]);
+        $dimensionContent->setRoute($route);
+
+        $tag = new TagMetadata();
+        $tag->setName(TemplateDataMapper::SKIP_TAG);
+
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('page_tree_route');
+        $routeField->addTag($tag);
+
+        $formMetadata = $this->prophesize(FormMetadata::class);
+        $formMetadata->getFlatFieldMetadata()->willReturn(['url' => $routeField]);
+
+        $typedFormMetadata = $this->prophesize(TypedFormMetadata::class);
+        $typedFormMetadata->getForms()->willReturn(['default' => $formMetadata->reveal()]);
+
+        $this->formMetadataProvider->getMetadata('page', 'en', [])->willReturn($typedFormMetadata->reveal());
+
+        $this->contentResolver->resolve(null, $routeField, 'en', Argument::type('array'))
+            ->willReturn(new ContentView(null, []));
+
+        $this->referenceStore->add('123-123-123', 'pages')->shouldBeCalled();
+
+        /** @var array{content: array<string, mixed>} $result */
+        $result = $this->structureResolver->resolve($dimensionContent, 'en', false);
+
+        $this->assertNull($result['content']['url']);
+    }
+
+    public function testResolvePageTreeRouteFieldSlugWithoutParentPrefix(): void
+    {
+        $parentRoute = new Route('pages', 'parent-uuid', 'en', '/parent');
+        $route = new Route('pages', 'page-uuid', 'en', '/completely-different', null, $parentRoute);
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu_io');
+        $page->setCreated(new \DateTimeImmutable('2024-01-01 10:00:00'));
+        $page->setChanged(new \DateTimeImmutable('2024-01-02 15:00:00'));
+
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setTemplateKey('default');
+        $dimensionContent->setTemplateData([]);
+        $dimensionContent->setRoute($route);
+
+        $tag = new TagMetadata();
+        $tag->setName(TemplateDataMapper::SKIP_TAG);
+
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('page_tree_route');
+        $routeField->addTag($tag);
+
+        $formMetadata = $this->prophesize(FormMetadata::class);
+        $formMetadata->getFlatFieldMetadata()->willReturn(['url' => $routeField]);
+
+        $typedFormMetadata = $this->prophesize(TypedFormMetadata::class);
+        $typedFormMetadata->getForms()->willReturn(['default' => $formMetadata->reveal()]);
+
+        $this->formMetadataProvider->getMetadata('page', 'en', [])->willReturn($typedFormMetadata->reveal());
+
+        $expectedValue = [
+            'page' => ['uuid' => 'parent-uuid', 'path' => '/parent'],
+            'suffix' => '',
+        ];
+        $this->contentResolver->resolve($expectedValue, $routeField, 'en', Argument::type('array'))
+            ->willReturn(new ContentView($expectedValue, []));
+
+        $this->referenceStore->add('123-123-123', 'pages')->shouldBeCalled();
+
+        /** @var array{content: array<string, array{page: array{path: string, uuid: string}, suffix: string}>} $result */
+        $result = $this->structureResolver->resolve($dimensionContent, 'en', false);
+
+        $this->assertSame('', $result['content']['url']['suffix']);
+    }
+
+    public function testResolveSkipsRouteFieldWithoutSkipTag(): void
+    {
+        $route = new Route('pages', 'page-uuid', 'en', '/my-slug');
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu_io');
+        $page->setCreated(new \DateTimeImmutable('2024-01-01 10:00:00'));
+        $page->setChanged(new \DateTimeImmutable('2024-01-02 15:00:00'));
+
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setTemplateKey('default');
+        $dimensionContent->setTemplateData(['url' => '/existing-value']);
+        $dimensionContent->setRoute($route);
+
+        $urlField = new FieldMetadata('url');
+        $urlField->setType('route');
+
+        $formMetadata = $this->prophesize(FormMetadata::class);
+        $formMetadata->getFlatFieldMetadata()->willReturn(['url' => $urlField]);
+
+        $typedFormMetadata = $this->prophesize(TypedFormMetadata::class);
+        $typedFormMetadata->getForms()->willReturn(['default' => $formMetadata->reveal()]);
+
+        $this->formMetadataProvider->getMetadata('page', 'en', [])->willReturn($typedFormMetadata->reveal());
+
+        $this->contentResolver->resolve('/existing-value', $urlField, 'en', Argument::type('array'))
+            ->willReturn(new ContentView('/existing-value', []));
+
+        $this->referenceStore->add('123-123-123', 'pages')->shouldBeCalled();
+
+        /** @var array{content: array<string, mixed>} $result */
+        $result = $this->structureResolver->resolve($dimensionContent, 'en', false);
+
+        $this->assertSame('/existing-value', $result['content']['url']);
     }
 }

--- a/Tests/Unit/Content/StructureResolverTest.php
+++ b/Tests/Unit/Content/StructureResolverTest.php
@@ -583,5 +583,4 @@ class StructureResolverTest extends TestCase
 
         $this->assertSame('', $result['content']['url']['suffix']);
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Bundle that provides controllers and services for using Sulu as headless content management system",
     "require": {
         "php": "^8.2",
-        "sulu/sulu": "^3.0.4@dev",
+        "sulu/sulu": "^3.0.6",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
         "symfony/framework-bundle": "^6.4 || ^7.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,37 +6,37 @@ parameters:
 			path: Content/ContentTypeResolver/SmartContentResolver.php
 
 		-
-			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<string\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<int\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: Content/DataProviderResolver/AccountDataProviderResolver.php
 
 		-
-			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<string\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<int\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: Content/DataProviderResolver/ArticleDataProviderResolver.php
 
 		-
-			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<string\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<int\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: Content/DataProviderResolver/ArticlePageTreeDataProviderResolver.php
 
 		-
-			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<string\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<int\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: Content/DataProviderResolver/ContactDataProviderResolver.php
 
 		-
-			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<string\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<int\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: Content/DataProviderResolver/MediaDataProviderResolver.php
 
 		-
-			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<string\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<int\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: Content/DataProviderResolver/PageDataProviderResolver.php
 
 		-
-			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<string\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Bundle\\\\AdminBundle\\\\SmartContent\\\\SmartContentProviderInterface\\:\\:findFlatBy\\(\\) expects array\\{categories\\: array\\<int\\>, categoryOperator\\: 'AND'\\|'OR', websiteCategories\\: array\\<string\\>, websiteCategoryOperator\\: 'AND'\\|'OR', tags\\: array\\<int\\>, tagOperator\\: 'AND'\\|'OR', websiteTags\\: array\\<string\\>, websiteTagOperator\\: 'AND'\\|'OR', \\.\\.\\.\\}, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: Content/DataProviderResolver/SnippetDataProviderResolver.php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Since Sulu 3.0.6, `route` and `page_tree_route` field values are no longer persisted in `templateData`. The URL is now owned by the `Route` entity and populated by `RoutableTemplateResolver` inside Sulu's content resolution chain. `StructureResolver` reads `templateData` directly and bypasses that chain, so a new `fillRouteFieldsFromRoute` method now populates those fields from the `Route` entity before resolution. Fields are identified using `TemplateDataMapper::SKIP_TAG`, which is the tag added by `RouteFieldSkipTemplateDataMapperFormMetadataVisitor` in 3.0.6 to mark fields not stored in `templateData`. Two navigation response fixtures are updated to reflect that `depth=1` now returns immediate children. `CreateSnippetTrait` is updated to resolve tag names to integer IDs, as `TaxonomyDataMapper` now requires IDs rather than name strings.

#### Why?

Upgrading to Sulu 3.0.6 caused all headless bundle tests that assert a `url` field in content responses to fail because `templateData['url']` is always null after the upgrade. The fix mirrors the approach Sulu uses internally in `RoutableTemplateResolver` without coupling to its decorator chain. The test infrastructure fixes address two further breaking changes in the 3.0.6 API that caused unrelated test failures.