### PR TITLE
Add localization urls to the headlessWebsiteController

### DIFF
--- a/Controller/HeadlessWebsiteController.php
+++ b/Controller/HeadlessWebsiteController.php
@@ -14,7 +14,12 @@ declare(strict_types=1);
 namespace Sulu\Bundle\HeadlessBundle\Controller;
 
 use Sulu\Bundle\HeadlessBundle\Content\StructureResolverInterface;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\RoutableInterface;
+use Sulu\Content\Infrastructure\Sulu\Route\Exception\WebspaceUrlNotFoundException;
 use Sulu\Content\UserInterface\Controller\Website\ContentController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -47,6 +52,10 @@ class HeadlessWebsiteController extends ContentController
         if ('json' === $requestFormat) {
             $locale = $object->getLocale() ?? 'en';
             $headlessData = $this->resolveHeadlessData($object, $locale);
+            $headlessData['localizations'] = $this->resolveHeadlessLocalizations(
+                $object,
+                $this->getHeadlessWebspaceKey($request),
+            );
 
             $response = new JsonResponse($headlessData);
             $response->headers->set('Content-Type', 'application/json');
@@ -72,6 +81,7 @@ class HeadlessWebsiteController extends ContentController
 
         $locale = $object->getLocale() ?? 'en';
         $parameters['headless'] = $this->resolveHeadlessData($object, $locale);
+        $parameters['headless']['localizations'] = $parameters['localizations'] ?? [];
 
         return $parameters;
     }
@@ -86,6 +96,86 @@ class HeadlessWebsiteController extends ContentController
     protected function resolveHeadlessData(DimensionContentInterface $object, string $locale): array
     {
         return $this->container->get('sulu_headless.structure_resolver')->resolve($object, $locale);
+    }
+
+    // TODO: remove once getSuluWebspaceKey() and resolveSuluLocalizations() are moved out of ContentController
+    //       see https://github.com/sulu/sulu/issues/8175
+    private function getHeadlessWebspaceKey(Request $request): string
+    {
+        $suluAttribute = $request->attributes->get('_sulu');
+
+        \assert($suluAttribute instanceof RequestAttributes, 'The "_sulu" request attribute must be of type ' . RequestAttributes::class . ', but got: ' . \get_debug_type($suluAttribute));
+        $attributes = $suluAttribute->getAttributes();
+        $webspace = $attributes['webspace'];
+        \assert($webspace instanceof Webspace, 'The "webspace" request attribute must be of type ' . Webspace::class . ', but got: ' . \get_debug_type($webspace));
+
+        return $webspace->getKey();
+    }
+
+    /**
+     * @param T $object
+     *
+     * @return array<string, array{url: string, locale: string, alternate: bool}>
+     *
+     * TODO: remove once getSuluWebspaceKey() and resolveSuluLocalizations() are moved out of ContentController
+     *       see https://github.com/sulu/sulu/issues/8175
+     */
+    private function resolveHeadlessLocalizations(DimensionContentInterface $object, string $webspaceKey): array
+    {
+        if (!$object instanceof RoutableInterface) {
+            return [];
+        }
+
+        $webspaceLocales = $this->container->get('sulu_core.webspace.webspace_manager')
+            ->getWebspaceCollection()
+            ->getWebspace($webspaceKey)
+            ?->getAllLocalizations() ?? [];
+
+        $localizations = [];
+        foreach ($webspaceLocales as $webspaceLocale) {
+            $locale = $webspaceLocale->getLocale(Localization::UNDERSCORE);
+            try {
+                $localizations[$locale] = [
+                    'url' => $this->container->get('sulu_route.route_generator')->generate(
+                        '/',
+                        $locale,
+                        $webspaceKey,
+                    ),
+                    'locale' => $locale,
+                    'alternate' => false,
+                ];
+            } catch (WebspaceUrlNotFoundException) {
+                continue;
+            }
+        }
+
+        $routes = [];
+        foreach ($this->container->get('sulu_route.route_repository')->findBy([
+            'resourceKey' => $object::getResourceKey(),
+            'resourceId' => (string) $object->getResource()->getId(),
+            'locales' => $object->getAvailableLocales() ?? [],
+        ]) as $route) {
+            $routes[] = $route;
+        }
+
+        foreach ($routes as $route) {
+            $locale = $route->getLocale();
+            try {
+                $localizations[$locale] = [
+                    'url' => $this->container->get('sulu_route.route_generator')->generate(
+                        $route->getSlug(),
+                        $route->getLocale(),
+                        $webspaceKey,
+                    ),
+                    'locale' => $locale,
+                    'alternate' => true,
+                ];
+            } catch (WebspaceUrlNotFoundException) {
+                continue;
+            }
+        }
+
+        return $localizations;
     }
 
     /**

--- a/Tests/Functional/Controller/HeadlessWebsiteControllerTest.php
+++ b/Tests/Functional/Controller/HeadlessWebsiteControllerTest.php
@@ -15,8 +15,13 @@ namespace Sulu\Bundle\HeadlessBundle\Tests\Functional\Controller;
 
 use Sulu\Bundle\HeadlessBundle\Tests\Functional\BaseTestCase;
 use Sulu\Bundle\HeadlessBundle\Tests\Traits\CreatePageTrait;
+use Sulu\Content\Domain\Model\WorkflowInterface;
+use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
+use Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage;
+use Sulu\Page\Application\Message\ModifyPageMessage;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\Envelope;
 
 class HeadlessWebsiteControllerTest extends BaseTestCase
 {
@@ -39,6 +44,39 @@ class HeadlessWebsiteControllerTest extends BaseTestCase
                 'title' => 'excerpt-title',
             ],
         ]);
+
+        $bothLocalesPage = self::createPage([
+            'title' => 'Both Locales',
+            'url' => '/both-locales',
+        ]);
+
+        $messageBus = static::getContainer()->get('sulu_message_bus');
+
+        $messageBus->dispatch(
+            new Envelope(
+                new ModifyPageMessage(
+                    ['uuid' => $bothLocalesPage->getUuid()],
+                    [
+                        'locale' => 'en',
+                        'template' => 'default',
+                        'title' => 'Both Locales EN',
+                        'url' => '/both-locales',
+                    ]
+                ),
+                [new EnableFlushStamp()]
+            )
+        );
+
+        $messageBus->dispatch(
+            new Envelope(
+                new ApplyWorkflowTransitionPageMessage(
+                    identifier: ['uuid' => $bothLocalesPage->getUuid()],
+                    locale: 'en',
+                    transitionName: WorkflowInterface::WORKFLOW_TRANSITION_PUBLISH
+                ),
+                [new EnableFlushStamp()]
+            )
+        );
 
         // Clear entity manager to ensure fresh state for routing
         self::getEntityManager()->clear();
@@ -88,6 +126,19 @@ class HeadlessWebsiteControllerTest extends BaseTestCase
 
         $this->assertResponseContent(
             'headless_website__test_index.json',
+            $response,
+            Response::HTTP_OK
+        );
+    }
+
+    public function testIndexActionLocalizationsAlternateTrueWhenBothLocalesExist(): void
+    {
+        $this->websiteClient->request('GET', '/both-locales.json');
+
+        $response = $this->websiteClient->getResponse();
+
+        $this->assertResponseContent(
+            'headless_website__both_locales.json',
             $response,
             Response::HTTP_OK
         );

--- a/Tests/Functional/Controller/Integration/responses/block/block__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/block/block__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/block__media.json
+++ b/Tests/Functional/Controller/Integration/responses/block/block__media.json
@@ -177,5 +177,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/block__multiple.json
+++ b/Tests/Functional/Controller/Integration/responses/block/block__multiple.json
@@ -197,5 +197,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/block__nested.json
+++ b/Tests/Functional/Controller/Integration/responses/block/block__nested.json
@@ -154,5 +154,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/block__text.json
+++ b/Tests/Functional/Controller/Integration/responses/block/block__text.json
@@ -146,5 +146,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/link__anchor.json
+++ b/Tests/Functional/Controller/Integration/responses/block/link__anchor.json
@@ -139,5 +139,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/link__external.json
+++ b/Tests/Functional/Controller/Integration/responses/block/link__external.json
@@ -139,5 +139,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/link__internal.json
+++ b/Tests/Functional/Controller/Integration/responses/block/link__internal.json
@@ -139,5 +139,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/link__null.json
+++ b/Tests/Functional/Controller/Integration/responses/block/link__null.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/text_editor__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/block/text_editor__basic.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/text_editor__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/block/text_editor__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/block/text_editor__markup.json
+++ b/Tests/Functional/Controller/Integration/responses/block/text_editor__markup.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/collection_selection__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/media/collection_selection__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/collection_selection__multiple.json
+++ b/Tests/Functional/Controller/Integration/responses/media/collection_selection__multiple.json
@@ -143,5 +143,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/image_map__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/media/image_map__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/image_map__hotspots.json
+++ b/Tests/Functional/Controller/Integration/responses/media/image_map__hotspots.json
@@ -185,5 +185,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/media_selection__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/media/media_selection__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/media_selection__multiple.json
+++ b/Tests/Functional/Controller/Integration/responses/media/media_selection__multiple.json
@@ -190,5 +190,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/media_selection__single.json
+++ b/Tests/Functional/Controller/Integration/responses/media/media_selection__single.json
@@ -163,5 +163,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/single_collection_selection__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/media/single_collection_selection__basic.json
@@ -139,5 +139,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/single_collection_selection__null.json
+++ b/Tests/Functional/Controller/Integration/responses/media/single_collection_selection__null.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/single_media_selection__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/media/single_media_selection__basic.json
@@ -159,5 +159,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/media/single_media_selection__null.json
+++ b/Tests/Functional/Controller/Integration/responses/media/single_media_selection__null.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/account_selection__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/account_selection__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/account_selection__multiple.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/account_selection__multiple.json
@@ -150,5 +150,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/article_selection__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/article_selection__empty.json
@@ -101,7 +101,9 @@
             "websiteCategoriesOperator": "OR",
             "websiteTags": [],
             "websiteTagsOperator": "OR",
-            "excluded": ["@uuid@"]
+            "excluded": [
+                "@uuid@"
+            ]
         },
         "blocks": []
     },
@@ -131,6 +133,18 @@
             "noIndex": false,
             "noFollow": false,
             "hideInSitemap": false
+        }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
         }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/article_selection__multiple.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/article_selection__multiple.json
@@ -73,7 +73,10 @@
         "title": [],
         "url": [],
         "article_selection": {
-            "ids": ["@uuid@", "@uuid@"]
+            "ids": [
+                "@uuid@",
+                "@uuid@"
+            ]
         },
         "text_editor": [],
         "link": [],
@@ -140,7 +143,9 @@
             "websiteCategoriesOperator": "OR",
             "websiteTags": [],
             "websiteTagsOperator": "OR",
-            "excluded": ["@uuid@"]
+            "excluded": [
+                "@uuid@"
+            ]
         },
         "blocks": []
     },
@@ -170,6 +175,18 @@
             "noIndex": false,
             "noFollow": false,
             "hideInSitemap": false
+        }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
         }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/category_selection__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/category_selection__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/category_selection__multiple.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/category_selection__multiple.json
@@ -152,5 +152,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/contact_account_selection__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/contact_account_selection__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/contact_account_selection__mixed.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/contact_account_selection__mixed.json
@@ -150,5 +150,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/contact_selection__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/contact_selection__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/contact_selection__multiple.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/contact_selection__multiple.json
@@ -150,5 +150,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/page_selection__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/page_selection__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/page_selection__multiple.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/page_selection__multiple.json
@@ -178,5 +178,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_account_selection__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_account_selection__basic.json
@@ -139,5 +139,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_account_selection__null.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_account_selection__null.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_article_selection__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_article_selection__basic.json
@@ -119,7 +119,9 @@
             "websiteCategoriesOperator": "OR",
             "websiteTags": [],
             "websiteTagsOperator": "OR",
-            "excluded": ["@uuid@"]
+            "excluded": [
+                "@uuid@"
+            ]
         },
         "blocks": []
     },
@@ -149,6 +151,18 @@
             "noIndex": false,
             "noFollow": false,
             "hideInSitemap": false
+        }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
         }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_article_selection__null.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_article_selection__null.json
@@ -101,7 +101,9 @@
             "websiteCategoriesOperator": "OR",
             "websiteTags": [],
             "websiteTagsOperator": "OR",
-            "excluded": ["@uuid@"]
+            "excluded": [
+                "@uuid@"
+            ]
         },
         "blocks": []
     },
@@ -131,6 +133,18 @@
             "noIndex": false,
             "noFollow": false,
             "hideInSitemap": false
+        }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
         }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_category_selection__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_category_selection__basic.json
@@ -140,5 +140,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_category_selection__null.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_category_selection__null.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_contact_selection__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_contact_selection__basic.json
@@ -139,5 +139,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_contact_selection__null.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_contact_selection__null.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_page_selection__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_page_selection__basic.json
@@ -153,5 +153,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_page_selection__null.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_page_selection__null.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_snippet_selection__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_snippet_selection__basic.json
@@ -150,5 +150,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/single_snippet_selection__null.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/single_snippet_selection__null.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/snippet_selection__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/snippet_selection__empty.json
@@ -134,5 +134,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/selection/snippet_selection__multiple.json
+++ b/Tests/Functional/Controller/Integration/responses/selection/snippet_selection__multiple.json
@@ -172,5 +172,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/smart-content/accounts__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/smart-content/accounts__basic.json
@@ -200,5 +200,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/smart-content/contacts__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/smart-content/contacts__basic.json
@@ -200,5 +200,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/smart-content/media__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/smart-content/media__basic.json
@@ -254,5 +254,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/smart-content/pages__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/smart-content/pages__basic.json
@@ -242,5 +242,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/smart-content/pages__empty.json
+++ b/Tests/Functional/Controller/Integration/responses/smart-content/pages__empty.json
@@ -200,5 +200,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/smart-content/pages__with_excerpt.json
+++ b/Tests/Functional/Controller/Integration/responses/smart-content/pages__with_excerpt.json
@@ -262,5 +262,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/Integration/responses/smart-content/snippets__basic.json
+++ b/Tests/Functional/Controller/Integration/responses/smart-content/snippets__basic.json
@@ -200,5 +200,17 @@
             "noFollow": false,
             "hideInSitemap": false
         }
+    },
+    "localizations": {
+        "de": {
+            "url": "@string@",
+            "locale": "de",
+            "alternate": true
+        },
+        "en": {
+            "url": "@string@",
+            "locale": "en",
+            "alternate": false
+        }
     }
 }

--- a/Tests/Functional/Controller/responses/headless_website__both_locales.json
+++ b/Tests/Functional/Controller/responses/headless_website__both_locales.json
@@ -4,8 +4,8 @@
     "type": "page",
     "template": "default",
     "content": {
-        "title": "Test",
-        "url": "/test",
+        "title": "Both Locales",
+        "url": "/both-locales",
         "article": null
     },
     "view": {
@@ -22,7 +22,7 @@
     "extension": {
         "seo": {
             "title": "",
-            "description": "seo-description",
+            "description": "",
             "keywords": "",
             "canonicalUrl": "",
             "noIndex": false,
@@ -30,7 +30,7 @@
             "hideInSitemap": false
         },
         "excerpt": {
-            "title": "excerpt-title",
+            "title": "",
             "more": "",
             "description": "",
             "categories": [],
@@ -50,7 +50,7 @@
         "en": {
             "url": "@string@",
             "locale": "en",
-            "alternate": false
+            "alternate": true
         }
     }
 }


### PR DESCRIPTION
Add localization to the HeadlessWebsiteController. The methods are copied from the ContentController, as they will probably be moved in the future. See also https://github.com/sulu/sulu/issues/8175