### PR TITLE
Point the AnalyticsController alias at the analytics controller

### DIFF
--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -32,7 +32,7 @@
             <argument>%sulu_headless.navigation.cache_lifetime%</argument>
         </service>
         <service id="Sulu\Bundle\HeadlessBundle\Controller\AnalyticsController"
-                 alias="sulu_headless.controller.navigation" public="true"/>
+                 alias="sulu_headless.controller.analytics" public="true"/>
 
         <service
             id="sulu_headless.controller.snippet_area"


### PR DESCRIPTION
The FQCN alias for `AnalyticsController` points at the navigation controller, so autowiring or fetching `Sulu\Bundle\HeadlessBundle\Controller\AnalyticsController` returns a `NavigationController` instead.

```xml
<service id="Sulu\Bundle\HeadlessBundle\Controller\AnalyticsController"
         alias="sulu_headless.controller.navigation" public="true"/>
```

The service right above it is `sulu_headless.controller.analytics`, which is what the alias should point to. Every other controller in the file aliases its own service, so this is a copy and paste slip rather than a deliberate choice.

Found by @Copilot while reviewing #166, which converts this file to PHP on `3.0`. As @alexander-schranz asked there, the same line is wrong on `1.1`, hence this pull request. `3.0` and `3.1` carry it too, and `3.0` is fixed in #166.
